### PR TITLE
NOJIRA: S3 Maven publish script

### DIFF
--- a/bintray.gradle
+++ b/bintray.gradle
@@ -69,8 +69,8 @@ afterEvaluate {
             maven {
                 url "s3://prod-rukkaz-cms/android_repo/"
                 credentials(AwsCredentials) {
-                    accessKey "AKIAXZEO74YEWRMHWPMI"
-                    secretKey "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"
+                    accessKey "SA_ANDROID_APPS_S3_REPO_KEY"
+                    secretKey "SA_ANDROID_APPS_S3_REPO_SECRET"
                 }
             }
         }

--- a/bintray.gradle
+++ b/bintray.gradle
@@ -19,46 +19,58 @@ ext {
     PROJECT_GROUP = group
 }
 
-publishing {
-    publications {
-        MyPublication(MavenPublication) {
-            pom.withXml {
-                asNode().with {
-                    getAt('packaging')[0].replaceNode { packaging('aar') }
-                    appendNode('name', this.publishDescription)
-                    appendNode('url', siteUrl)
-
-                    appendNode('licenses').with {
-                        appendNode('license').with {
-                            appendNode('name', 'The Apache Software License, Version 2.0')
-                            appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
-                        }
-                    }
-
-                    appendNode('developers').with {
-                        appendNode('developer').with {
-                            appendNode('id', 'gabrielcoman')
-                            appendNode('name', 'Gabriel Coman')
-                            appendNode('email', 'gabriel.coman@superawesome.tv')
-                        }
-                    }
-
-                    appendNode('scm').with {
-                        appendNode('connection', gitUrl)
-                        appendNode('developerConnection', gitUrl)
+afterEvaluate {
+    publishing {
+        publications {
+            MyPublication(MavenPublication) {
+                from components.release
+                pom.withXml {
+                    asNode().with {
+                        getAt('packaging')[0].replaceNode { packaging('aar') }
+                        appendNode('name', this.publishDescription)
                         appendNode('url', siteUrl)
+
+                        appendNode('licenses').with {
+                            appendNode('license').with {
+                                appendNode('name', 'The Apache Software License, Version 2.0')
+                                appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
+                            }
+                        }
+
+                        appendNode('developers').with {
+                            appendNode('developer').with {
+                                appendNode('id', 'gabrielcoman')
+                                appendNode('name', 'Gabriel Coman')
+                                appendNode('email', 'gabriel.coman@superawesome.tv')
+                            }
+                        }
+
+                        appendNode('scm').with {
+                            appendNode('connection', gitUrl)
+                            appendNode('developerConnection', gitUrl)
+                            appendNode('url', siteUrl)
+                        }
+                    }
+
+                    def dependenciesNode = asNode().getAt('dependencies')[0] ?: asNode().appendNode('dependencies')
+                    configurations.implementation.allDependencies.each {
+                        if (it.name != 'unspecified') {
+                            def dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', it.group)
+                            dependencyNode.appendNode('artifactId', it.name)
+                            dependencyNode.appendNode('version', it.version)
+                            dependencyNode.appendNode('scope', 'compile')
+                        }
                     }
                 }
-
-                def dependenciesNode = asNode().getAt('dependencies')[0] ?: asNode().appendNode('dependencies')
-                configurations.implementation.allDependencies.each {
-                    if (it.name != 'unspecified') {
-                        def dependencyNode = dependenciesNode.appendNode('dependency')
-                        dependencyNode.appendNode('groupId', it.group)
-                        dependencyNode.appendNode('artifactId', it.name)
-                        dependencyNode.appendNode('version', it.version)
-                        dependencyNode.appendNode('scope', 'compile')
-                    }
+            }
+        }
+        repositories {
+            maven {
+                url "s3://prod-rukkaz-cms/android_repo/"
+                credentials(AwsCredentials) {
+                    accessKey "AKIAXZEO74YEWRMHWPMI"
+                    secretKey "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"
                 }
             }
         }

--- a/bintray.gradle
+++ b/bintray.gradle
@@ -1,5 +1,9 @@
+import groovy.json.JsonSlurper
+
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
+
+def parsedJson = new JsonSlurper().parseText(new File(System.getProperty("user.home") + '/.superawesome/credentials.json').text)
 
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
@@ -69,8 +73,8 @@ afterEvaluate {
             maven {
                 url "s3://prod-rukkaz-cms/android_repo/"
                 credentials(AwsCredentials) {
-                    accessKey "SA_ANDROID_APPS_S3_REPO_KEY"
-                    secretKey "SA_ANDROID_APPS_S3_REPO_SECRET"
+                    accessKey parsedJson.get("SA_ANDROID_APPS_S3_REPO_KEY")
+                    secretKey parsedJson.get("SA_ANDROID_APPS_S3_REPO_SECRET")
                 }
             }
         }

--- a/bintray.gradle
+++ b/bintray.gradle
@@ -76,21 +76,3 @@ afterEvaluate {
         }
     }
 }
-
-bintray {
-    user = properties.getProperty("bintray.user")
-    key = properties.getProperty("bintray.apikey")
-
-    configurations = ['archives']
-    publications = ['MyPublication']
-
-    pkg {
-        repo = "SuperAwesomeSDK"
-        name = this.publishName
-        userOrg = 'superawesome'
-        websiteUrl = siteUrl
-        vcsUrl = gitUrl
-        licenses = ["Apache-2.0"]
-        publish = true
-    }
-}


### PR DESCRIPTION
This PR removes the bin tray publish code and adds the replacement S3 maven repository code.

This points to `s3://prod-rukkaz-cms/android_repo/` and is a temporary solution for the moment, it will be moved to a permanent location in the next sprint (sprint I).

To publish the library, type the following in terminal: `./gradlew publish`