### PR TITLE
NOJIRA: Fix no run CI build step on Master merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,8 +144,6 @@ workflows:
       - test_superawesome_base:
           context: MOBILE_ANDROID_SDKS
           filters:
-            tags:
-              only: /^v.*/
             branches:
               ignore: develop
       - semantic_release:


### PR DESCRIPTION
## JIRA
NO JIRA

## DESCRIPTION
This PR fixes the master build and release process on the CI, currently it doesn't run the jobs as the filter is too restrictive.

## SCREENSHOTS
![Screenshot 2021-08-18 at 15 46 30](https://user-images.githubusercontent.com/618350/129919700-cd55e812-b772-45b1-ab5e-68749fd6c76e.png)
