### PR TITLE
NOJIRA: Exported manifest tags

### DIFF
--- a/superawesome-base/src/main/AndroidManifest.xml
+++ b/superawesome-base/src/main/AndroidManifest.xml
@@ -7,32 +7,31 @@
         android:supportsRtl="true">
         <activity
             android:name="tv.superawesome.sdk.publisher.SAVideoActivity"
+            android:exported="false"
             android:label="SAFullscreenVideoAd"
             android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"
             android:configChanges="keyboardHidden|orientation|screenSize"/>
 
         <activity
             android:name="tv.superawesome.sdk.publisher.SAInterstitialAd"
+            android:exported="false"
             android:label="SAInterstitialAd"
             android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"
             android:configChanges="keyboardHidden|orientation|screenSize"/>
 
         <activity
             android:name="tv.superawesome.sdk.publisher.managed.SAManagedInterstitialAd"
+            android:exported="false"
             android:label="SAManagedInterstitialAd"
             android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"
             android:configChanges="keyboardHidden|orientation|screenSize"/>
 
         <activity
             android:name="tv.superawesome.lib.sabumperpage.SABumperPage"
+            android:exported="false"
             android:label="SABumperPage"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:theme="@android:style/Theme.Holo.Dialog.NoActionBar"
             android:excludeFromRecents="true"/>
-
-<!--        <activity android:name="tv.superawesome.sdk.publisher.test.SingleTestActivity"-->
-<!--            android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"-->
-<!--            android:screenOrientation="portrait"/>-->
-
     </application>
 </manifest>

--- a/superawesome/src/main/AndroidManifest.xml
+++ b/superawesome/src/main/AndroidManifest.xml
@@ -1,11 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="tv.superawesome.sdk">
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
+    
 </manifest>


### PR DESCRIPTION
This PR adds the missing `android:exported="true"` tags to the activities, this is required for Android 12 apps.