### PR TITLE
fix(): use gha-token-generator and set GITHUB_TOKEN env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,12 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Generate & store Github Token
+          command: |
+            curl -L https://github.com/SuperAwesomeLTD/gha-token-generator/releases/download/v1.0.3/gha-token-generator_1.0.3_Linux_x86_64.tar.gz | tar xz
+            GENERATED_APP_TOKEN=$( ./gha-token-generator -app-id ${SA_GITHUB_CIRCLECI_DOWNLOAD_TOOLS_APP_ID} -org-name SuperAwesomeLTD -pem-key ${SA_GITHUB_CIRCLECI_DOWNLOAD_TOOLS_APP_PEM} )
+            echo "export GITHUB_TOKEN=${GENERATED_APP_TOKEN}" >> $BASH_ENV
+      - run:
           name: Run semantic release
           command: |
             git clone "${SA_CONTINUOUS_INTEGRATION_GIT_REPO_URL}" "${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}"


### PR DESCRIPTION
Let's see if this works. It should be enough as the `semantic_release` error is:
```
A GitHub personal token (https://github.com/semantic-release/github/blob/master/README.md#github-authentication) must be created and set in the GH_TOKEN or GITHUB_TOKEN environment variable on your CI environment.
```