### PR TITLE
chore(AAG-1641): use generated github token before each continuous-integration pull

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,19 @@ references:
       JAVA_TOOL_OPTIONS: "-Xmx2048m"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
 
+  generate_github_token: &generate_github_token
+    run:
+      name: Generate & store Github Token
+      command: |
+        curl -L https://github.com/SuperAwesomeLTD/gha-token-generator/releases/download/v1.0.3/gha-token-generator_1.0.3_Linux_x86_64.tar.gz | tar xz
+        GENERATED_APP_TOKEN=$( ./gha-token-generator -app-id ${SA_GITHUB_CIRCLECI_DOWNLOAD_TOOLS_APP_ID} -org-name SuperAwesomeLTD -pem-key ${SA_GITHUB_CIRCLECI_DOWNLOAD_TOOLS_APP_PEM} )
+        echo "export GITHUB_TOKEN=${GENERATED_APP_TOKEN}" >> $BASH_ENV
+
   bootstrap: &bootstrap
     run:
       name: Bootstrap
       command: |
-        git clone "${SA_CONTINUOUS_INTEGRATION_GIT_REPO_URL}" "${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}"
+        git clone https://x-access-token:${GITHUB_TOKEN}@github.com/SuperAwesomeLTD/sa-continuous-integration.git "${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}"
         ${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}/bootstrap/bootstrap-mobile-android-sdk.sh
 
 jobs:
@@ -24,6 +32,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *generate_github_token
       - *bootstrap
       - run:
           name: Lint Code
@@ -42,15 +51,9 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Generate & store Github Token
-          command: |
-            curl -L https://github.com/SuperAwesomeLTD/gha-token-generator/releases/download/v1.0.3/gha-token-generator_1.0.3_Linux_x86_64.tar.gz | tar xz
-            GENERATED_APP_TOKEN=$( ./gha-token-generator -app-id ${SA_GITHUB_CIRCLECI_DOWNLOAD_TOOLS_APP_ID} -org-name SuperAwesomeLTD -pem-key ${SA_GITHUB_CIRCLECI_DOWNLOAD_TOOLS_APP_PEM} )
-            echo "export GITHUB_TOKEN=${GENERATED_APP_TOKEN}" >> $BASH_ENV
-      - run:
           name: Run semantic release
           command: |
-            git clone "${SA_CONTINUOUS_INTEGRATION_GIT_REPO_URL}" "${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}"
+            git clone https://x-access-token:${GITHUB_TOKEN}@github.com/SuperAwesomeLTD/sa-continuous-integration.git "${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}"
             ${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}/semantic-release/semantic-release.sh
 
   #Await for all running builds to finish
@@ -67,6 +70,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *generate_github_token
       - *bootstrap
       - run:
           name: Push Superawesome-All to the S3 Repo
@@ -76,6 +80,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *generate_github_token
       - *bootstrap
       - run:
           name: Push Superawesome-Base to the S3 Repo
@@ -85,6 +90,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *generate_github_token
       - *bootstrap
       - run:
           name: Push Superawesome-AdMob to the S3 Repo
@@ -94,6 +100,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *generate_github_token
       - *bootstrap
       - run:
           name: Push Superawesome-Moat to the S3 Repo
@@ -103,6 +110,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *generate_github_token
       - *bootstrap
       - run:
           name: Push Superawesome-MoPub to the S3 Repo
@@ -112,6 +120,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *generate_github_token
       - *bootstrap
       - run:
           name: Push Superawesome-Unity to the S3 Repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
     <<: *android_config
     steps:
       - checkout
+      - *generate_github_token
       - run:
           name: Run semantic release
           command: |


### PR DESCRIPTION
In order for us to remove the user token from our circleCI project, we need a generated github token to be available in each instance we pull / use the continuous-integration repo. Since we do this across multiple _jobs_, we need to generate the token within each separate job (as variables are available between steps, not separate jobs in the same pipeline - this would require persisting to workspace).

Instead of going through the hassle of persisting it to the workspace for use across all jobs, we can just set a reference and run the generate github token step each time we need it.