### PR TITLE
Aag 1591 callback logs

### DIFF
--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SABannerAd.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SABannerAd.java
@@ -164,7 +164,7 @@ public class SABannerAd extends FrameLayout {
                     if (listener != null) {
                         SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
                         listener.onEvent(placementId, eventToSend);
-                        Log.d("SABannerAd.load", "Event callback: " + eventToSend.toString());
+                        Log.d("SABannerAd.load.PL_ID", "Event callback: " + eventToSend.toString());
                     } else {
                         Log.w("AwesomeAds", "Banner Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                     }
@@ -232,7 +232,7 @@ public class SABannerAd extends FrameLayout {
                     if (listener != null) {
                         SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
                         listener.onEvent(placementId, eventToSend);
-                        Log.d("SABannerAd.load", "Event callback: " + eventToSend.toString());
+                        Log.d("SABannerAd.load.ALL_IDs", "Event callback: " + eventToSend.toString());
                     } else {
                         Log.w("AwesomeAds", "Banner Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                     }

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SABannerAd.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SABannerAd.java
@@ -448,6 +448,7 @@ public class SABannerAd extends FrameLayout {
         // callback
         if (listener != null) {
             listener.onEvent(ad.placementId, SAEvent.adClicked);
+            Log.d("SABannerAd.handleUrl", "Event callback: " + SAEvent.adClicked.toString());
         } else {
             Log.w("AwesomeAds", "Banner Ad listener not implemented. Event would have been adClicked");
         }

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SABannerAd.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SABannerAd.java
@@ -164,7 +164,7 @@ public class SABannerAd extends FrameLayout {
                     if (listener != null) {
                         SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
                         listener.onEvent(placementId, eventToSend);
-                        Log.d("SABannerAd.load.PL_ID", "Event callback: " + eventToSend.toString());
+                        Log.d("SABannerAd", "Event callback: " + eventToSend.toString());
                     } else {
                         Log.w("AwesomeAds", "Banner Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                     }
@@ -232,7 +232,7 @@ public class SABannerAd extends FrameLayout {
                     if (listener != null) {
                         SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
                         listener.onEvent(placementId, eventToSend);
-                        Log.d("SABannerAd.load.ALL_IDs", "Event callback: " + eventToSend.toString());
+                        Log.d("SABannerAd", "Event callback: " + eventToSend.toString());
                     } else {
                         Log.w("AwesomeAds", "Banner Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                     }
@@ -302,7 +302,7 @@ public class SABannerAd extends FrameLayout {
                         // call listener
                         if (listener != null) {
                             listener.onEvent(ad.placementId, SAEvent.adShown);
-                            Log.d("SABannerAd.play", "Event callback: " + SAEvent.adShown.toString());
+                            Log.d("SABannerAd", "Event callback: " + SAEvent.adShown.toString());
                         } else {
                             Log.w("AwesomeAds", "Banner Ad listener not implemented. Event would have been adShown");
                         }
@@ -448,7 +448,7 @@ public class SABannerAd extends FrameLayout {
         // callback
         if (listener != null) {
             listener.onEvent(ad.placementId, SAEvent.adClicked);
-            Log.d("SABannerAd.handleUrl", "Event callback: " + SAEvent.adClicked.toString());
+            Log.d("SABannerAd", "Event callback: " + SAEvent.adClicked.toString());
         } else {
             Log.w("AwesomeAds", "Banner Ad listener not implemented. Event would have been adClicked");
         }
@@ -485,7 +485,7 @@ public class SABannerAd extends FrameLayout {
         // de-set public listener
         if (listener != null) {
             listener.onEvent(ad != null ? ad.placementId : 0, SAEvent.adClosed);
-            Log.d("SABannerAd.close", "Event callback: " + SAEvent.adClosed.toString());
+            Log.d("SABannerAd", "Event callback: " + SAEvent.adClosed.toString());
         } else {
             Log.w("AwesomeAds", "Banner Ad listener not implemented. Event would have been adClosed");
         }

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SABannerAd.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SABannerAd.java
@@ -162,7 +162,9 @@ public class SABannerAd extends FrameLayout {
                     canPlay = response.isValid();
                     setAd(response.isValid() ? response.ads.get(0) : null);
                     if (listener != null) {
-                        listener.onEvent(placementId, response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty);
+                        SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
+                        listener.onEvent(placementId, eventToSend);
+                        Log.d("SABannerAd.load", "Event callback: " + eventToSend.toString());
                     } else {
                         Log.w("AwesomeAds", "Banner Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                     }
@@ -228,7 +230,9 @@ public class SABannerAd extends FrameLayout {
                     canPlay = response.isValid();
                     setAd(response.isValid() ? response.ads.get(0) : null);
                     if (listener != null) {
-                        listener.onEvent(placementId, response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty);
+                        SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
+                        listener.onEvent(placementId, eventToSend);
+                        Log.d("SABannerAd.load", "Event callback: " + eventToSend.toString());
                     } else {
                         Log.w("AwesomeAds", "Banner Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                     }
@@ -298,6 +302,7 @@ public class SABannerAd extends FrameLayout {
                         // call listener
                         if (listener != null) {
                             listener.onEvent(ad.placementId, SAEvent.adShown);
+                            Log.d("SABannerAd.play", "Event callback: " + SAEvent.adShown.toString());
                         } else {
                             Log.w("AwesomeAds", "Banner Ad listener not implemented. Event would have been adShown");
                         }
@@ -479,6 +484,7 @@ public class SABannerAd extends FrameLayout {
         // de-set public listener
         if (listener != null) {
             listener.onEvent(ad != null ? ad.placementId : 0, SAEvent.adClosed);
+            Log.d("SABannerAd.close", "Event callback: " + SAEvent.adClosed.toString());
         } else {
             Log.w("AwesomeAds", "Banner Ad listener not implemented. Event would have been adClosed");
         }

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAInterstitialAd.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAInterstitialAd.java
@@ -255,7 +255,9 @@ public class SAInterstitialAd extends Activity implements SABannerAd.VisibilityL
 
                         // call listener
                         if (listener != null) {
-                            listener.onEvent(placementId, response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty);
+                            SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
+                            listener.onEvent(placementId, eventToSend);
+                            Log.d("SAInterstitialAd.load", "Event callback: " + eventToSend.toString());
                         } else {
                             Log.w("AwesomeAds", "Interstitial Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                         }
@@ -350,7 +352,9 @@ public class SAInterstitialAd extends Activity implements SABannerAd.VisibilityL
 
                         // call listener
                         if (listener != null) {
-                            listener.onEvent(placementId, response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty);
+                            SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
+                            listener.onEvent(placementId, eventToSend);
+                            Log.d("SAInterstitialAd.load", "Event callback: " + eventToSend.toString());
                         } else {
                             Log.w("AwesomeAds", "Interstitial Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                         }

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAInterstitialAd.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAInterstitialAd.java
@@ -188,7 +188,6 @@ public class SAInterstitialAd extends Activity implements SABannerAd.VisibilityL
      * @param placementId   the Ad placement id to load data for
      * @param context       the current context
      */
-    @SuppressLint("LongLogTag")
     public static void load(final int placementId, Context context) {
 
         // very late init of the AwesomeAds SDK
@@ -259,7 +258,7 @@ public class SAInterstitialAd extends Activity implements SABannerAd.VisibilityL
                         if (listener != null) {
                             SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
                             listener.onEvent(placementId, eventToSend);
-                            Log.d("SAInterstitialAd.load.PL_ID", "Event callback: " + eventToSend.toString());
+                            Log.d("SAInterstitialAd", "Event callback: " + eventToSend.toString());
                         } else {
                             Log.w("AwesomeAds", "Interstitial Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                         }
@@ -286,7 +285,6 @@ public class SAInterstitialAd extends Activity implements SABannerAd.VisibilityL
      * @param placementId   the Ad placement id to load data for
      * @param context       the current context
      */
-    @SuppressLint("LongLogTag")
     public static void load(final int placementId, final int lineItemId, final int creativeId, Context context) {
 
         // very late init of the AwesomeAds SDK
@@ -357,7 +355,7 @@ public class SAInterstitialAd extends Activity implements SABannerAd.VisibilityL
                         if (listener != null) {
                             SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
                             listener.onEvent(placementId, eventToSend);
-                            Log.d("SAInterstitialAd.load.ALL_IDs", "Event callback: " + eventToSend.toString());
+                            Log.d("SAInterstitialAd", "Event callback: " + eventToSend.toString());
                         } else {
                             Log.w("AwesomeAds", "Interstitial Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                         }

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAInterstitialAd.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAInterstitialAd.java
@@ -4,6 +4,7 @@
  */
 package tv.superawesome.sdk.publisher;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -187,6 +188,7 @@ public class SAInterstitialAd extends Activity implements SABannerAd.VisibilityL
      * @param placementId   the Ad placement id to load data for
      * @param context       the current context
      */
+    @SuppressLint("LongLogTag")
     public static void load(final int placementId, Context context) {
 
         // very late init of the AwesomeAds SDK
@@ -257,7 +259,7 @@ public class SAInterstitialAd extends Activity implements SABannerAd.VisibilityL
                         if (listener != null) {
                             SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
                             listener.onEvent(placementId, eventToSend);
-                            Log.d("SAInterstitialAd.load", "Event callback: " + eventToSend.toString());
+                            Log.d("SAInterstitialAd.load.PL_ID", "Event callback: " + eventToSend.toString());
                         } else {
                             Log.w("AwesomeAds", "Interstitial Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                         }
@@ -284,6 +286,7 @@ public class SAInterstitialAd extends Activity implements SABannerAd.VisibilityL
      * @param placementId   the Ad placement id to load data for
      * @param context       the current context
      */
+    @SuppressLint("LongLogTag")
     public static void load(final int placementId, final int lineItemId, final int creativeId, Context context) {
 
         // very late init of the AwesomeAds SDK
@@ -354,7 +357,7 @@ public class SAInterstitialAd extends Activity implements SABannerAd.VisibilityL
                         if (listener != null) {
                             SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
                             listener.onEvent(placementId, eventToSend);
-                            Log.d("SAInterstitialAd.load", "Event callback: " + eventToSend.toString());
+                            Log.d("SAInterstitialAd.load.ALL_IDs", "Event callback: " + eventToSend.toString());
                         } else {
                             Log.w("AwesomeAds", "Interstitial Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                         }

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoActivity.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoActivity.java
@@ -14,6 +14,7 @@ import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.ImageView;
@@ -99,6 +100,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
         chrome.setClickListener(view -> {
             videoClick.handleAdClick(view);
             listenerRef.onEvent(ad.placementId, SAEvent.adClicked);
+            Log.d("VideoActivity.onCreate", "Event callback: " + SAEvent.adClicked.toString());
         });
         chrome.padlock.setOnClickListener(view -> videoClick.handleSafeAdClick(view));
 
@@ -166,6 +168,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
 
         if (listenerRef != null) {
             listenerRef.onEvent(ad.placementId, SAEvent.adShown);
+            Log.d("SAVideoActivity.onPrep", "Event callback: " + SAEvent.adShown.toString());
         }
     }
 

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoActivity.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoActivity.java
@@ -4,6 +4,7 @@
  */
 package tv.superawesome.sdk.publisher;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
@@ -61,6 +62,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
      *
      * @param savedInstanceState previous saved state
      */
+    @SuppressLint("LongLogTag")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -100,7 +102,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
         chrome.setClickListener(view -> {
             videoClick.handleAdClick(view);
             listenerRef.onEvent(ad.placementId, SAEvent.adClicked);
-            Log.d("VideoActivity.onCreate", "Event callback: " + SAEvent.adClicked.toString());
+            Log.d("SAVideoActivity.onCreate", "Event callback: " + SAEvent.adClicked.toString());
         });
         chrome.padlock.setOnClickListener(view -> videoClick.handleSafeAdClick(view));
 
@@ -161,6 +163,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
     // VideoPlayer.VisibilityListener
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
+    @SuppressLint("LongLogTag")
     @Override
     public void onPrepared(@NonNull IVideoPlayer videoPlayer, int time, int duration) {
 
@@ -168,7 +171,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
 
         if (listenerRef != null) {
             listenerRef.onEvent(ad.placementId, SAEvent.adShown);
-            Log.d("SAVideoActivity.onPrep", "Event callback: " + SAEvent.adShown.toString());
+            Log.d("SAVideoActivity.onPrepared", "Event callback: " + SAEvent.adShown.toString());
         }
     }
 
@@ -177,6 +180,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
         videoEvents.time(videoPlayer, time, duration);
     }
 
+    @SuppressLint("LongLogTag")
     @Override
     public void onComplete(@NonNull IVideoPlayer videoPlayer, int time, int duration) {
         completed = true;
@@ -185,6 +189,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
 
         if (listenerRef != null) {
             listenerRef.onEvent(ad.placementId, SAEvent.adEnded);
+            Log.d("SAVideoActivity.onComplete", "Event callback: " + SAEvent.adEnded.toString());
         }
 
         if (config.shouldCloseAtEnd) {
@@ -237,6 +242,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
         // call listener
         if (listenerRef != null) {
             listenerRef.onEvent(ad.placementId, SAEvent.adClosed);
+            Log.d("SAVideoActivity.close", "Event callback: " + SAEvent.adClosed.toString());
         }
 
         // close

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoActivity.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoActivity.java
@@ -62,7 +62,6 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
      *
      * @param savedInstanceState previous saved state
      */
-    @SuppressLint("LongLogTag")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -102,7 +101,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
         chrome.setClickListener(view -> {
             videoClick.handleAdClick(view);
             listenerRef.onEvent(ad.placementId, SAEvent.adClicked);
-            Log.d("SAVideoActivity.onCreate", "Event callback: " + SAEvent.adClicked.toString());
+            Log.d("SAVideoActivity", "Event callback: " + SAEvent.adClicked.toString());
         });
         chrome.padlock.setOnClickListener(view -> videoClick.handleSafeAdClick(view));
 
@@ -163,7 +162,6 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
     // VideoPlayer.VisibilityListener
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
-    @SuppressLint("LongLogTag")
     @Override
     public void onPrepared(@NonNull IVideoPlayer videoPlayer, int time, int duration) {
 
@@ -171,7 +169,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
 
         if (listenerRef != null) {
             listenerRef.onEvent(ad.placementId, SAEvent.adShown);
-            Log.d("SAVideoActivity.onPrepared", "Event callback: " + SAEvent.adShown.toString());
+            Log.d("SAVideoActivity", "Event callback: " + SAEvent.adShown.toString());
         }
     }
 
@@ -180,7 +178,6 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
         videoEvents.time(videoPlayer, time, duration);
     }
 
-    @SuppressLint("LongLogTag")
     @Override
     public void onComplete(@NonNull IVideoPlayer videoPlayer, int time, int duration) {
         completed = true;
@@ -189,7 +186,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
 
         if (listenerRef != null) {
             listenerRef.onEvent(ad.placementId, SAEvent.adEnded);
-            Log.d("SAVideoActivity.onComplete", "Event callback: " + SAEvent.adEnded.toString());
+            Log.d("SAVideoActivity", "Event callback: " + SAEvent.adEnded.toString());
         }
 
         if (config.shouldCloseAtEnd) {
@@ -242,7 +239,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
         // call listener
         if (listenerRef != null) {
             listenerRef.onEvent(ad.placementId, SAEvent.adClosed);
-            Log.d("SAVideoActivity.close", "Event callback: " + SAEvent.adClosed.toString());
+            Log.d("SAVideoActivity", "Event callback: " + SAEvent.adClosed.toString());
         }
 
         // close

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoAd.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoAd.java
@@ -101,7 +101,7 @@ public class SAVideoAd {
                         if (listener != null) {
                             SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
                             listener.onEvent(placementId, eventToSend);
-                            Log.d("SAVideoAd.load.PL_ID", "Event callback: " + eventToSend.toString());
+                            Log.d("SAVideoAd", "Event callback: " + eventToSend.toString());
                         } else {
                             Log.w("AwesomeAds", "Video Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                         }
@@ -179,7 +179,7 @@ public class SAVideoAd {
                         if (listener != null) {
                             SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
                             listener.onEvent(placementId, eventToSend);
-                            Log.d("SAVideoAd.load.All_IDs", "Event callback: " + eventToSend.toString());
+                            Log.d("SAVideoAd", "Event callback: " + eventToSend.toString());
                         } else {
                             Log.w("AwesomeAds", "Video Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                         }

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoAd.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoAd.java
@@ -99,7 +99,9 @@ public class SAVideoAd {
 
                         // call listener(s)
                         if (listener != null) {
-                            listener.onEvent(placementId, isValid ? SAEvent.adLoaded : SAEvent.adEmpty);
+                            SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
+                            listener.onEvent(placementId, eventToSend);
+                            Log.d("SAInterstitialAd.load", "Event callback: " + eventToSend.toString());
                         } else {
                             Log.w("AwesomeAds", "Video Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                         }
@@ -175,7 +177,9 @@ public class SAVideoAd {
 
                         // call listener(s)
                         if (listener != null) {
-                            listener.onEvent(placementId, isValid ? SAEvent.adLoaded : SAEvent.adEmpty);
+                            SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
+                            listener.onEvent(placementId, eventToSend);
+                            Log.d("SAInterstitialAd.load", "Event callback: " + eventToSend.toString());
                         } else {
                             Log.w("AwesomeAds", "Video Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                         }

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoAd.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoAd.java
@@ -101,7 +101,7 @@ public class SAVideoAd {
                         if (listener != null) {
                             SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
                             listener.onEvent(placementId, eventToSend);
-                            Log.d("SAInterstitialAd.load", "Event callback: " + eventToSend.toString());
+                            Log.d("SAVideoAd.load.PL_ID", "Event callback: " + eventToSend.toString());
                         } else {
                             Log.w("AwesomeAds", "Video Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                         }
@@ -179,7 +179,7 @@ public class SAVideoAd {
                         if (listener != null) {
                             SAEvent eventToSend = response.isValid() ? SAEvent.adLoaded : SAEvent.adEmpty;
                             listener.onEvent(placementId, eventToSend);
-                            Log.d("SAInterstitialAd.load", "Event callback: " + eventToSend.toString());
+                            Log.d("SAVideoAd.load.All_IDs", "Event callback: " + eventToSend.toString());
                         } else {
                             Log.w("AwesomeAds", "Video Ad listener not implemented. Event would have been either adLoaded or adEmpty");
                         }


### PR DESCRIPTION
Adding debug logs for:
- adLoaded
- adShown
- adClicked
- adEnded
- adClosed

Debug logs can now be seen in Logcat, and can easily be found by keeping a filter on for `Event callback: `.

Video below showing debug logs being registered and easily seen for the above callbacks.

https://user-images.githubusercontent.com/48458132/152332378-b6dee0f5-41da-4c4f-b136-2be1805b9419.mov

