### PR TITLE
chore(): add debug logs for tracking event triggers

### DIFF
--- a/superawesome-base/src/main/java/tv/superawesome/lib/saevents/SAEvents.java
+++ b/superawesome-base/src/main/java/tv/superawesome/lib/saevents/SAEvents.java
@@ -1,6 +1,7 @@
 package tv.superawesome.lib.saevents;
 
 import android.app.Application;
+import android.util.Log;
 import android.view.ViewGroup;
 import android.webkit.WebView;
 import android.widget.VideoView;
@@ -40,24 +41,28 @@ public class SAEvents {
     public void triggerClickEvent () {
         if (serverModule != null) {
             serverModule.triggerClickEvent(null);
+            Log.d("Event_Tracking", "click");
         }
     }
 
     public void triggerImpressionEvent () {
         if (serverModule != null) {
             serverModule.triggerImpressionEvent(null);
+            Log.d("Event_Tracking", "impression");
         }
     }
 
     public void triggerDwellTime(){
         if (serverModule != null) {
             serverModule.triggerDwellEvent(null);
+            Log.d("Event_Tracking", "dwellTime");
         }
     }
 
     public void triggerViewableImpressionEvent () {
         if (serverModule != null) {
             serverModule.triggerViewableImpressionEvent(null);
+            Log.d("Event_Tracking", "viewableImpression");
         }
     }
 
@@ -100,60 +105,70 @@ public class SAEvents {
     public void triggerVASTClickThroughEvent () {
         if (vastModule != null) {
             vastModule.triggerVastClickThroughEvent(null);
+            Log.d("Event_Tracking", "vast_click_through");
         }
     }
 
     public void triggerVASTErrorEvent () {
         if (vastModule != null) {
             vastModule.triggerVASTErrorEvent(null);
+            Log.d("Event_Tracking", "vast_error");
         }
     }
 
     public void triggerVASTImpressionEvent () {
         if (vastModule != null) {
             vastModule.triggerVASTImpressionEvent(null);
+            Log.d("Event_Tracking", "vast_impression");
         }
     }
 
     public void triggerVASTCreativeViewEvent () {
         if (vastModule != null) {
             vastModule.triggerVASTCreativeViewEvent(null);
+            Log.d("Event_Tracking", "vast_creativeView");
         }
     }
 
     public void triggerVASTStartEvent () {
         if (vastModule != null) {
             vastModule.triggerVASTStartEvent(null);
+            Log.d("Event_Tracking", "vast_start");
         }
     }
 
     public void triggerVASTFirstQuartileEvent () {
         if (vastModule != null) {
             vastModule.triggerVASTFirstQuartileEvent(null);
+            Log.d("Event_Tracking", "vast_firstQuartile");
         }
     }
 
     public void triggerVASTMidpointEvent () {
         if (vastModule != null) {
             vastModule.triggerVASTMidpointEvent(null);
+            Log.d("Event_Tracking", "vast_midpoint");
         }
     }
 
     public void triggerVASTThirdQuartileEvent () {
         if (vastModule != null) {
             vastModule.triggerVASTThirdQuartileEvent(null);
+            Log.d("Event_Tracking", "vast_thirdQuartile");
         }
     }
 
     public void triggerVASTCompleteEvent () {
         if (vastModule != null) {
             vastModule.triggerVASTCompleteEvent(null);
+            Log.d("Event_Tracking", "vast_complete");
         }
     }
 
     public void triggerVASTClickTrackingEvent () {
         if (vastModule != null) {
             vastModule.triggerVASTClickTrackingEvent(null);
+            Log.d("Event_Tracking", "vast_click_tracking");
         }
     }
 
@@ -190,6 +205,7 @@ public class SAEvents {
             triggerMoatAttemptNoClassEvent();
             return "";
         }
+        Log.d("Event_Tracking", "moat: display");
         return moatModule.startMoatTrackingForDisplay(view);
     }
 
@@ -206,6 +222,7 @@ public class SAEvents {
             final boolean result =
                     moatModule.startMoatTrackingForVideoPlayer(videoView, duration, isAllowed, moatModule.hasMoatInstance());
             if (result) {
+                Log.d("Event_Tracking", "moat: video");
                 triggerMoatSuccessEvent();
             } else {
                 triggerMoatErrorEvent();
@@ -242,26 +259,32 @@ public class SAEvents {
     }
 
     public boolean sendMoatPlayingEvent (int position) {
+        Log.d("Event_Tracking", "moat: playing");
         return moatModule == null || moatModule.sendPlayingEvent(position);
     }
 
     public boolean sendMoatStartEvent (int position) {
+        Log.d("Event_Tracking", "moat: start");
         return moatModule == null || moatModule.sendStartEvent(position);
     }
 
     public boolean sendMoatFirstQuartileEvent (int position) {
+        Log.d("Event_Tracking", "moat: firstQuartile");
         return moatModule == null || moatModule.sendFirstQuartileEvent(position);
     }
 
     public boolean sendMoatMidpointEvent (int position) {
+        Log.d("Event_Tracking", "moat: midpoint");
         return moatModule == null || moatModule.sendMidpointEvent(position);
     }
 
     public boolean sendMoatThirdQuartileEvent (int position) {
+    Log.d("Event_Tracking", "moat: thirdQuartile");
         return moatModule == null || moatModule.sendThirdQuartileEvent(position);
     }
 
     public boolean sendMoatCompleteEvent (int position) {
+        Log.d("Event_Tracking", "moat: complete");
         return moatModule == null || moatModule.sendCompleteEvent(position);
     }
 


### PR DESCRIPTION
Adding debug logs for event tracking triggers. We can see event triggers being sent for:
- Moat events
- Impressions
- Viewable Impressions
- Click events
- Quartiles
- ViewTime (dwellTime)

These can then be found in Logcat by filtering for `Event_Tracking` when interacting with placements.

<img width="1868" alt="Screenshot 2022-02-07 at 14 01 23" src="https://user-images.githubusercontent.com/48458132/152802330-ac2fd4c7-1768-46c6-8be2-7d796664fc7d.png">
