### PR TITLE
Update README with link-out to Confluence page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,4 @@ For more information check out the [SuperAwesome Developer Portal](https://super
 **Contributing to the Android SDK**
 
 - To contribute to the Android SDK, create a new branch with your desired commits.
-- Our automated build pipeline uses semantic-release to release the correct version based on the commits provided in the release. In order to release the desired version number (patch, minor or major), use the following commit message prefaces:
-  - For a **patch** release, i.e. from `X.X.1` to `X.X.2`, preface the commit message with either `fix()` or `perf()`
-  - For a **minor** release, i.e. from `X.1.X` to `X.2.X`, preface the commit message with `feat()`
-  - For a **major** release, i.e. from `1.X.X` to `2.X.X`, preface the commit message with `BREAKING CHANGE:`
-- Create a Pull Request, and once merged, the automated build pipeline will release the desired version.
+- Create a pull request, and once it's merged, our automated build pipeline will release a new version based on the commit message prefaces given. You can find out more about the necessary commit prefaces for your desired release version [here](https://superawesomeltd.atlassian.net/wiki/spaces/AA/pages/4932993069/Releasing+Versions+with+Semantic+Release).


### PR DESCRIPTION
The semantic release information is useful to be written in multiple repos - by storing it in one place in Confluence, we can just link it into multiple repos instead.