### PR TITLE
fix(): fix for missing ads on Unity Android

### DIFF
--- a/saunity/src/main/java/tv/superawesome/plugins/publisher/unity/SAUnityBannerAd.java
+++ b/saunity/src/main/java/tv/superawesome/plugins/publisher/unity/SAUnityBannerAd.java
@@ -59,7 +59,7 @@ public class SAUnityBannerAd {
     public static void SuperAwesomeUnitySABannerAdLoad(Context context, String unityName, int placementId, int configuration, boolean test) {
         if (bannerAdHashMap.containsKey(unityName)) {
             SABannerAd bannerAd = bannerAdHashMap.get(unityName);
-            bannerAd.setConfiguration(SAConfiguration.fromOrdinal(configuration));
+            bannerAd.setConfiguration(SAConfiguration.fromValue(configuration));
             bannerAd.setTestMode(test);
             bannerAd.load(placementId);
         }

--- a/saunity/src/main/java/tv/superawesome/plugins/publisher/unity/SAUnityInterstitialAd.java
+++ b/saunity/src/main/java/tv/superawesome/plugins/publisher/unity/SAUnityInterstitialAd.java
@@ -62,7 +62,7 @@ public class SAUnityInterstitialAd {
      */
     public static void SuperAwesomeUnitySAInterstitialAdLoad(Context context, int placementId, int configuration, boolean test) {
         SAInterstitialAd.setTestMode(test);
-        SAInterstitialAd.setConfiguration(SAConfiguration.fromOrdinal(configuration));
+        SAInterstitialAd.setConfiguration(SAConfiguration.fromValue(configuration));
         SAInterstitialAd.load(placementId, context);
     }
 

--- a/saunity/src/main/java/tv/superawesome/plugins/publisher/unity/SAUnityVideoAd.java
+++ b/saunity/src/main/java/tv/superawesome/plugins/publisher/unity/SAUnityVideoAd.java
@@ -66,7 +66,7 @@ public class SAUnityVideoAd {
                                                       boolean test,
                                                       int playback) {
         SAVideoAd.setTestMode(test);
-        SAVideoAd.setConfiguration(SAConfiguration.fromOrdinal(configuration));
+        SAVideoAd.setConfiguration(SAConfiguration.fromValue(configuration));
         SAVideoAd.setPlaybackMode(SARTBStartDelay.fromValue(playback));
         SAVideoAd.load(placementId, context);
     }

--- a/superawesome-base/src/test/java/tv/superawesome/lib/sasession/defines/SAConfigurationTest.java
+++ b/superawesome-base/src/test/java/tv/superawesome/lib/sasession/defines/SAConfigurationTest.java
@@ -9,6 +9,10 @@ import java.util.List;
 
 public class SAConfigurationTest  {
 
+    private static final int DEV = -1;
+    private static final int PRODUCTION = 0;
+    private static final int STAGING = 1;
+
     @Test
     public void test_ensure_parcel_and_un_parcel_works_dev(){
         // arrange
@@ -57,7 +61,7 @@ public class SAConfigurationTest  {
         SAConfiguration expected = SAConfiguration.DEV;
 
         // act
-        SAConfiguration actual = SAConfiguration.fromValue(-1);
+        SAConfiguration actual = SAConfiguration.fromValue(DEV);
 
         // assert
         assertEquals(expected,actual);
@@ -69,7 +73,7 @@ public class SAConfigurationTest  {
         SAConfiguration expected = SAConfiguration.STAGING;
 
         // act
-        SAConfiguration actual = SAConfiguration.fromValue(1);
+        SAConfiguration actual = SAConfiguration.fromValue(STAGING);
 
         // assert
         assertEquals(expected,actual);
@@ -81,7 +85,7 @@ public class SAConfigurationTest  {
         SAConfiguration expected = SAConfiguration.PRODUCTION;
 
         // act
-        SAConfiguration actual = SAConfiguration.fromValue(0);
+        SAConfiguration actual = SAConfiguration.fromValue(PRODUCTION);
 
         // assert
         assertEquals(expected,actual);

--- a/superawesome-base/src/test/java/tv/superawesome/lib/sasession/defines/SAConfigurationTest.java
+++ b/superawesome-base/src/test/java/tv/superawesome/lib/sasession/defines/SAConfigurationTest.java
@@ -51,4 +51,40 @@ public class SAConfigurationTest  {
         assertEquals(expected,actual);
     }
 
+    @Test
+    public void test_ensure_fromValue_returns_expected_config_Dev(){
+        // arrange
+        SAConfiguration expected = SAConfiguration.DEV;
+
+        // act
+        SAConfiguration actual = SAConfiguration.fromValue(-1);
+
+        // assert
+        assertEquals(expected,actual);
+    }
+
+    @Test
+    public void test_ensure_fromValue_returns_expected_config_Staging(){
+        // arrange
+        SAConfiguration expected = SAConfiguration.STAGING;
+
+        // act
+        SAConfiguration actual = SAConfiguration.fromValue(1);
+
+        // assert
+        assertEquals(expected,actual);
+    }
+
+    @Test
+    public void test_ensure_fromValue_returns_expected_config_Production(){
+        // arrange
+        SAConfiguration expected = SAConfiguration.PRODUCTION;
+
+        // act
+        SAConfiguration actual = SAConfiguration.fromValue(0);
+
+        // assert
+        assertEquals(expected,actual);
+    }
+
 }


### PR DESCRIPTION

This PR fixes an issue where Ads wouldn't load on Unity Android. This was caused by using the `fromOrdinal` method which relies on the index position in the `SAConfiguration` of `Production` or `Staging` but the `SAConfiguration` in the Android SDK has another case `Dev` which was causing a mismatch. It seems to be safer overall to use the `fromValue` method which matches on the enum `rawValue` rather than the index position.