### PR TITLE
Feat/aag 2057 set semantic release to develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ references:
       - image: circleci/android:api-30
     resource_class: medium
     environment:
-      SA_SEMANTIC_RELEASE_RUN_BRANCH: develop
       FL_OUTPUT_DIR: output
       TERM: dumb
       JAVA_TOOL_OPTIONS: "-Xmx2048m"
@@ -49,6 +48,8 @@ jobs:
 
   semantic_release:
     <<: *android_config
+    environment:
+      SA_SEMANTIC_RELEASE_RUN_BRANCH: develop
     steps:
       - checkout
       - *generate_github_token

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ references:
       - image: circleci/android:api-30
     resource_class: medium
     environment:
+      SA_SEMANTIC_RELEASE_RUN_BRANCH: develop
       FL_OUTPUT_DIR: output
       TERM: dumb
       JAVA_TOOL_OPTIONS: "-Xmx2048m"


### PR DESCRIPTION
This PR sets the semantic release environment to develop. I'll need to also change the default branch for the repo to `develop`