### PR TITLE
Replaced site.baseurl with site.root

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,6 +8,7 @@ description: >
   AwesomeAds Android Publisher SDK
 
 baseurl: "/"
+root: "/"
 
 # This is mostly for testing
 url: "https://sa-mobile-sdk-android.superawesome.tv"

--- a/docs/_docs/admob-integration.md
+++ b/docs/_docs/admob-integration.md
@@ -35,27 +35,27 @@ Login to the AdMob dashboard using your preferred account.
 
 From here forward the tutorial assumes you have an Android app with three ad units setup in AdMob; one banner, one interstitial ad and one rewarded video ad:
 
-![image-title-here]({{ site.baseurl }}/assets/img/IMG_08_AdMob_1.png){:class="img-responsive"}
+![image-title-here]({{ site.root }}/assets/img/IMG_08_AdMob_1.png){:class="img-responsive"}
 
 Then, in the `Mediation` menu, create a new Mediation Group:
 
-![image-title-here]({{ site.baseurl }}/assets/img/IMG_08_AdMob_2.png){:class="img-responsive"}
+![image-title-here]({{ site.root }}/assets/img/IMG_08_AdMob_2.png){:class="img-responsive"}
 
 Next, `Add Custom Event` as an Ad Source:
 
-![image-title-here]({{ site.baseurl }}/assets/img/IMG_08_AdMob_3.png){:class="img-responsive"}
+![image-title-here]({{ site.root }}/assets/img/IMG_08_AdMob_3.png){:class="img-responsive"}
 
 and add your app’s banner `Ad Unit` as target:
 
-![image-title-here]({{ site.baseurl }}/assets/img/IMG_08_AdMob_4.png){:class="img-responsive"}
+![image-title-here]({{ site.root }}/assets/img/IMG_08_AdMob_4.png){:class="img-responsive"}
 
 Then, in the `Ad Sources` panel, add a new `Custom Event`:
 
-![image-title-here]({{ site.baseurl }}/assets/img/IMG_08_AdMob_5.png){:class="img-responsive"}
+![image-title-here]({{ site.root }}/assets/img/IMG_08_AdMob_5.png){:class="img-responsive"}
 
 and, as well, customise it:
 
-![image-title-here]({{ site.baseurl }}/assets/img/IMG_08_AdMob_6.png){:class="img-responsive"}
+![image-title-here]({{ site.root }}/assets/img/IMG_08_AdMob_6.png){:class="img-responsive"}
 
 Notice that the custom event class names required by AdMob are:
  - <strong>for Banner Ads:</strong>

--- a/docs/_docs/bumper-page.md
+++ b/docs/_docs/bumper-page.md
@@ -41,7 +41,7 @@ SABumperPage.overrideLogo(R.drawable.__MY_CUSTOM_LOGO__);
 
 By default the Bumper page will try to use the application name and the AwesomeAds logo and will look like following:
 
-![image-title-here]({{ site.baseurl }}/assets/img/IMG_06_BumperPage.png){:class="img-responsive"}
+![image-title-here]({{ site.root }}/assets/img/IMG_06_BumperPage.png){:class="img-responsive"}
 
 ## Forcing the bumper
 

--- a/docs/_docs/parental-gate.md
+++ b/docs/_docs/parental-gate.md
@@ -24,7 +24,7 @@ SAVideoAd.enableParentalGate();
 
 The final result will look something similar to this:
 
-![image-title-here]({{ site.baseurl }}/assets/img/IMG_06_ParentalGate.png){:class="img-responsive"}
+![image-title-here]({{ site.root }}/assets/img/IMG_06_ParentalGate.png){:class="img-responsive"}
 
 These are the default values:
 

--- a/docs/_docs/prepare.md
+++ b/docs/_docs/prepare.md
@@ -6,7 +6,7 @@ description: Preparing SDK
 
 The first step in integrating the {{ site.title }} is to register on the [SuperAwesome Dashboard](http://dashboard.superawesome.tv/).
 
-![image-title-here]({{ site.baseurl }}/assets/img/IMG_01_Dashboard_1.png){:class="img-responsive"}
+![image-title-here]({{ site.root }}/assets/img/IMG_01_Dashboard_1.png){:class="img-responsive"}
 
 From here you’ll be able to create apps and placements, obtain performance reports (number of impressions, clicks), view current revenue, etc.
 
@@ -16,7 +16,7 @@ When first logging in to the dashboard, the first thing you’ll want to do is c
 
 Each app has a number of associated parameters such as ID, name, domain (or iTunes URL), etc. The name and domain can be configured when you create the app, while the ID is automatically assigned so as to be unique to each app.
 
-![image-title-here]({{ site.baseurl }}/assets/img/IMG_01_Dashboard_3.png){:class="img-responsive"}
+![image-title-here]({{ site.root }}/assets/img/IMG_01_Dashboard_3.png){:class="img-responsive"}
 
 In turn, each app can have multiple placements.
 
@@ -24,7 +24,7 @@ In turn, each app can have multiple placements.
 
 Placements represent ad units where creatives will be served. Creatives are the actual ad data that gets shown in your app, like images, videos, interactive rich media content, etc.
 
-![image-title-here]({{ site.baseurl }}/assets/img/IMG_01_Dashboard_4.png){:class="img-responsive"}
+![image-title-here]({{ site.root }}/assets/img/IMG_01_Dashboard_4.png){:class="img-responsive"}
 
 Each placement has a number of associated parameters like ID, name, format, dimension.
 

--- a/docs/_includes/doc.html
+++ b/docs/_includes/doc.html
@@ -1,1 +1,1 @@
-<a href="{{ site.baseurl }}/docs/{{ include.path }}">{% if include.name %}{{ include.name }}{% else %}{{ include.path }}{% endif %}</a>
+<a href="{{ site.root }}/docs/{{ include.path }}">{% if include.name %}{{ include.name }}{% else %}{{ include.path }}{% endif %}</a>

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -7,16 +7,16 @@
 
 <link rel="alternate" type="application/rss&#43;xml" href="/docs/index.xml">
 
-<link rel="shortcut icon" href="{{ site.baseurl }}/assets/favicons/favicon.ico" >
-<link rel="apple-touch-icon" href="{{ site.baseurl }}/assets/favicons/apple-touch-icon-180x180.png" sizes="180x180">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/favicon-16x16.png" sizes="16x16">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/favicon-32x32.png" sizes="32x32">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-36x36.png" sizes="36x36">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-48x48.png" sizes="48x48">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-72x72.png" sizes="72x72">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-96x196.png" sizes="96x196">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-144x144.png" sizes="144x144">
-<link rel="icon" type="image/png" href="{{ site.baseurl }}/assets/favicons/android-192x192.png"sizes="192x192">
+<link rel="shortcut icon" href="{{ site.root }}/assets/favicons/favicon.ico" >
+<link rel="apple-touch-icon" href="{{ site.root }}/assets/favicons/apple-touch-icon-180x180.png" sizes="180x180">
+<link rel="icon" type="image/png" href="{{ site.root }}/assets/favicons/favicon-16x16.png" sizes="16x16">
+<link rel="icon" type="image/png" href="{{ site.root }}/assets/favicons/favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="{{ site.root }}/assets/favicons/android-36x36.png" sizes="36x36">
+<link rel="icon" type="image/png" href="{{ site.root }}/assets/favicons/android-48x48.png" sizes="48x48">
+<link rel="icon" type="image/png" href="{{ site.root }}/assets/favicons/android-72x72.png" sizes="72x72">
+<link rel="icon" type="image/png" href="{{ site.root }}/assets/favicons/android-96x196.png" sizes="96x196">
+<link rel="icon" type="image/png" href="{{ site.root }}/assets/favicons/android-144x144.png" sizes="144x144">
+<link rel="icon" type="image/png" href="{{ site.root }}/assets/favicons/android-192x192.png"sizes="192x192">
 
 <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
 <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
@@ -32,8 +32,8 @@
 <meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}"/>
 <meta name="twitter:description" content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}"/>
 
-<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">
-<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/palette.css">
+<link rel="stylesheet" href="{{ site.root }}/assets/css/main.css">
+<link rel="stylesheet" href="{{ site.root }}/assets/css/palette.css">
 <script
   src="https://code.jquery.com/jquery-3.3.1.min.js"
   integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,13 +1,13 @@
 <header>
         <nav class="js-navbar-scroll navbar navbar-expand navbar-dark flex-column flex-md-row td-navbar">
-        <a class="navbar-brand" href="{{ site.baseurl }}/">
+        <a class="navbar-brand" href="{{ site.root }}/">
             <span class="navbar-logo"></span>{% include logo.svg %}<span class="">{{ site.title }}</span>
 	</a>
 	<div class="td-navbar-nav-scroll ml-md-auto" id="main_navbar">
 		<ul class="navbar-nav mt-2 mt-lg-0">{% if site.repo %}
       {% endif %}{% for link in site.data.navigation %}
 			<li class="nav-item mr-4 mb-2 mb-lg-0">
-        <a class="nav-link" href="{% if link.url %}{{ site.baseurl }}/{{ link.url }}{% else %}{{ link.external_url }}{% endif %}" ><span>{{ link.title }}</span></a>
+        <a class="nav-link" href="{% if link.url %}{{ site.root }}/{{ link.url }}{% else %}{{ link.external_url }}{% endif %}" ><span>{{ link.title }}</span></a>
 			</li>{% endfor %}
 		</ul>
 	</div>

--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -12,7 +12,7 @@
             <div class=md-flex>
                 <div class="md-flex__cell md-flex__cell--shrink">
                   <a class="md-header-nav__button md-logo" href="{{ site.url }}" title="{{ site.title }}">
-                    {% if site.logo %}<img height="{{ site.logo_pixels }}" src="{{ site.baseurl }}/{{ site.logo }}" width="{{ site.logo_pixels }}">{% else %}<i class="md-icon" style="margin-top:5px"></i>{% endif %}</a>
+                    {% if site.logo %}<img height="{{ site.logo_pixels }}" src="{{ site.root }}/{{ site.logo }}" width="{{ site.logo_pixels }}">{% else %}<i class="md-icon" style="margin-top:5px"></i>{% endif %}</a>
                 </div>
                 <div class="md-flex__cell md-flex__cell--shrink">
                     <label class="md-icon md-icon--menu md-header-nav__button" for=__drawer></label>

--- a/docs/_includes/scripts.html
+++ b/docs/_includes/scripts.html
@@ -1,3 +1,3 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
-<script src="{{ site.baseurl }}/assets/js/main.js"></script>
+<script src="{{ site.root }}/assets/js/main.js"></script>

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -9,16 +9,16 @@
   {% capture sectionUrl %}{{ section.url | replace: "/", "" }}{% endcapture %}
   {% capture pageUrl %}{{ page.url | replace: "/", "" }}{% endcapture %}
   <li class="td-sidebar-nav__section-title">
-    <a  href="{% if section.url %}{{ site.baseurl }}/{{ section.url }}{% else %}{{ section.external_url }}{% endif %}" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">{{ section.title }}</a>
+    <a  href="{% if section.url %}{{ site.root }}/{{ section.url }}{% else %}{{ section.external_url }}{% endif %}" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">{{ section.title }}</a>
   </li>{% if section.links %}<ul>
     <li class="collapse show" id="{{ section.title | slugify }}">
         <ul class="td-sidebar-nav__section pr-md-3">{% for entry in section.links %}
           <li class="td-sidebar-nav__section-title">
-            <a href="{% if entry.url %}{{ site.baseurl }}/{{ entry.url }}{% else %}{{ entry.external_url }}{% endif %}" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section {% if page.url contains  entry.url  %}active{% endif %}">{{ entry.title }}</a>
+            <a href="{% if entry.url %}{{ site.root }}/{{ entry.url }}{% else %}{{ entry.external_url }}{% endif %}" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section {% if page.url contains  entry.url  %}active{% endif %}">{{ entry.title }}</a>
           </li>
           {% if page.url contains entry.url or pageUrl == sectionUrl %}
           <ul><li class="collapse show" id="{{ child.title | slugify }}">{% if entry.children %}
-              {% for child in entry.children %}<a class="td-sidebar-link td-sidebar-link__page " id="m-{{ section.title | slugify }}-{{ entry.title | slugify }}-{{ child.title | slugify }}" href="{% if child.url %}{{ site.baseurl }}/{{ child.url }}{% else %}{{ child.external_url }}{% endif %}">{{ child.title }}</a>{% endfor %}
+              {% for child in entry.children %}<a class="td-sidebar-link td-sidebar-link__page " id="m-{{ section.title | slugify }}-{{ entry.title | slugify }}-{{ child.title | slugify }}" href="{% if child.url %}{{ site.root }}/{{ child.url }}{% else %}{{ child.external_url }}{% endif %}">{{ child.title }}</a>{% endfor %}
               {% endif %}</li></ul>
               {% endif %}   
               {% endfor %}

--- a/docs/_includes/tags.html
+++ b/docs/_includes/tags.html
@@ -1,2 +1,2 @@
 {% if page.tags %}<script>
-$('h1').first().append('<div>{% for tag in page.tags %}<span style="font-size:12px" class="badge badge-{{ site.tag_color }}"><a style="cursor:pointer; color:white" href="{% if site.tag_search_endpoint %}{{ site.tag_search_endpoint }}{{ tag }}{% else %}{{ site.url }}{{ site.baseurl }}/tags#{{ tag }} {% endif %}">{{ tag }}</a></span>{% endfor %}</div>')</script>{% endif %}
+$('h1').first().append('<div>{% for tag in page.tags %}<span style="font-size:12px" class="badge badge-{{ site.tag_color }}"><a style="cursor:pointer; color:white" href="{% if site.tag_search_endpoint %}{{ site.tag_search_endpoint }}{{ tag }}{% else %}{{ site.url }}{{ site.root }}/tags#{{ tag }} {% endif %}">{{ tag }}</a></span>{% endfor %}</div>')</script>{% endif %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -26,10 +26,10 @@
               {% assign crumbs = page.url | append: "/"  | replace: '//', '/' | split: '/' %}
               {% for crumb in crumbs offset: 1 %}{% if crumb != "index" %}{% if forloop.last %}
                 <li class="breadcrumb-item active" aria-current="page">
-	          <a href="{{ site.url }}{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a>
+	          <a href="{{ site.url }}{{ site.root }}{{ page.url }}">{{ page.title }}</a>
                 </li>{% else %}
                 {% if page.url != "/docs/" %}<li class="breadcrumb-item">
-                  <a href="{{ site.url }}{{ site.baseurl }}{% assign crumb_limit = forloop.index | plus: 1 %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' }}{% endfor %}">{% if crumb == "docs" %}Documentation{% else %}{{ crumb | replace:'-',' ' | remove:'.html' | capitalize }}{% endif %}</a>
+                  <a href="{{ site.url }}{{ site.root }}{% assign crumb_limit = forloop.index | plus: 1 %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' }}{% endfor %}">{% if crumb == "docs" %}Documentation{% else %}{{ crumb | replace:'-',' ' | remove:'.html' | capitalize }}{% endif %}</a>
                 </li>{% endif %}{% endif %}
                 {% endif %}{% endfor %}
 	      </ol>
@@ -40,7 +40,7 @@
                <hr class="panel-line">{% for child in section.links %}
                  <div class="entry">
                     <h5>
-                        <a href="{% if child.url %}{{ site.baseurl }}{{ child.url }}{% else %}{{ child.external_url }}{% endif %}">{{ child.title }}</a>
+                        <a href="{% if child.url %}{{ site.root }}{{ child.url }}{% else %}{{ child.external_url }}{% endif %}">{{ child.title }}</a>
                     </h5>
                     <p>{{ child.description }}</p>
                  </div>{% endfor %}

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -49,7 +49,7 @@ layout: null
                         return
                     }
                     var query = $(this).val();
-                    var searchPage = "{{ site.url }}{{ site.baseurl }}/search/?q=" + query;
+                    var searchPage = "{{ site.url }}{{ site.root }}/search/?q=" + query;
                     document.location = searchPage;
                     return false;
                 });

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -71,7 +71,7 @@ excluded_in_search: true
                                 if (item.title) {
 					contentPreview = getPreview(query, item.content, 170),
 					titlePreview = getPreview(query, item.title);
-					resultsHTML += "<li><h4><a href='{{ site.baseurl }}" + item.url.trim() + "'>" + titlePreview + "</a></h4><p><small>" + contentPreview + "</small></p></li>";
+					resultsHTML += "<li><h4><a href='{{ site.root }}" + item.url.trim() + "'>" + titlePreview + "</a></h4><p><small>" + contentPreview + "</small></p></li>";
 				}
 			});
 

--- a/docs/pages/archive.md
+++ b/docs/pages/archive.md
@@ -10,7 +10,7 @@ permalink: /archive/
 {% if forloop.first %}<h2 class="c-archives__year" id="{{ this_year }}-ref">{{this_year}}</h2>
 <ul class="c-archives__list">{% endif %}
 <li class="c-archives__item">
-  {{ post.date | date: "%b %-d, %Y" }}: <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+  {{ post.date | date: "%b %-d, %Y" }}: <a href="{{ post.url | prepend: site.root }}">{{ post.title }}</a>
   </li>{% if forloop.last %}</ul>{% else %}{% if this_year != next_year %}
 </ul>
 <h2 class="c-archives__year" id="{{ next_year }}-ref">{{next_year}}</h2>

--- a/docs/pages/docs.md
+++ b/docs/pages/docs.md
@@ -13,7 +13,7 @@ particular page.
     <hr class="panel-line">
     {% for post in site.docs  %}        
     <div class="entry">
-    <h5><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h5>
+    <h5><a href="{{ post.url | prepend: site.root }}">{{ post.title }}</a></h5>
     <p>{{ post.description }}</p>
     </div>{% endfor %}
 </div>

--- a/docs/pages/feed.xml
+++ b/docs/pages/feed.xml
@@ -7,8 +7,8 @@ permalink: /feed.xml
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>{{ site.url }}{{ site.baseurl }}/</link>
-    <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <link>{{ site.url }}{{ site.root }}/</link>
+    <atom:link href="{{ "/feed.xml" | prepend: site.root | prepend: site.url }}" rel="self" type="application/rss+xml"/>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
@@ -17,8 +17,8 @@ permalink: /feed.xml
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
-        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        <link>{{ post.url | prepend: site.root | prepend: site.url }}</link>
+        <guid isPermaLink="true">{{ post.url | prepend: site.root | prepend: site.url }}</guid>
         {% for tag in post.tags %}
         <category>{{ tag | xml_escape }}</category>
         {% endfor %}

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -22,7 +22,7 @@ Here you can quickly jump to a particular page.
     <hr class="panel-line">
     {% for post in site.docs  %}        
     <div class="entry">
-    <h5><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h5>
+    <h5><a href="{{ post.url | prepend: site.root }}">{{ post.title }}</a></h5>
     <p>{{ post.description }}</p>
     </div>{% endfor %}
 </div>

--- a/docs/pages/news.md
+++ b/docs/pages/news.md
@@ -5,22 +5,22 @@ permalink: /news/
 
 # News
 
-<p>Subscribe with <a href="{{ site.baseurl }}/feed.xml">RSS</a> to keep up with the latest news.
+<p>Subscribe with <a href="{{ site.root }}/feed.xml">RSS</a> to keep up with the latest news.
 For site changes, see the <a href="https://github.com/{{ site.github_user }}/{{ site.github_repo }}/blob/master/CHANGELOG.md">changelog</a> kept with the code base.</p>
 
 <br>
 
 {% for post in site.posts limit:10 %}
    <div class="post-preview">
-   <h2><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h2>
+   <h2><a href="{{ site.root }}{{ post.url }}">{{ post.title }}</a></h2>
    <span class="post-date">{{ post.date | date: "%B %d, %Y" }}</span><br>
    {% if post.badges %}{% for badge in post.badges %}<span class="badge badge-{{ badge.type }}">{{ badge.tag }}</span>{% endfor %}{% endif %}
    {{ post.content | split:'<!--more-->' | first }}
    {% if post.content contains '<!--more-->' %}
-      <a href="{{ site.baseurl }}{{ post.url }}">read more</a>
+      <a href="{{ site.root }}{{ post.url }}">read more</a>
    {% endif %}
    </div>
    <hr>
 {% endfor %}
 
-Want to see more? See the <a href="{{ site.baseurl }}/archive/">News Archive</a>.
+Want to see more? See the <a href="{{ site.root }}/archive/">News Archive</a>.

--- a/docs/pages/search.html
+++ b/docs/pages/search.html
@@ -59,5 +59,5 @@ excluded_in_search: true
 		{% endfor %}
 	};
 </script>
-<script src="{{ site.baseurl }}/assets/js/lunr.min.js"></script>
-<script src="{{ site.baseurl }}/assets/js/search.js"></script>
+<script src="{{ site.root }}/assets/js/lunr.min.js"></script>
+<script src="{{ site.root }}/assets/js/search.js"></script>

--- a/docs/pages/sitemap.xml
+++ b/docs/pages/sitemap.xml
@@ -11,7 +11,7 @@ permalink: /sitemap.xml
      <changefreq>daily</changefreq>
     </url>
 {% for section in site.data.toc %}<url>
-     <loc>{{ site.baseurl }}{{ section.url }}/</loc>
+     <loc>{{ site.root }}{{ section.url }}/</loc>
      <lastmod>{{ "now" | date: "%Y-%m-%d" }}</lastmod>
      <changefreq>daily</changefreq>
     </url>

--- a/docs/pages/tags.html
+++ b/docs/pages/tags.html
@@ -15,7 +15,7 @@ permalink: /tags/
 </div>{%- endfor -%}
 {% for doc in site.docs %}{% if doc.tags contains tag %}
 <div class="tag-entry">
-    <a href="{{- site.baseurl -}}{{- doc.url -}}">{{ doc.title }}</a>
+    <a href="{{- site.root -}}{{- doc.url -}}">{{ doc.title }}</a>
         <time style="font-style:italic; float:right" datetime="{{- doc.date | date_to_xmlschema -}}"> {{- doc.date | date: "%B %d, %Y" -}}</time>
     </div>{% endif %}{% endfor %}
 </div>{% endif %}{%- endfor -%}


### PR DESCRIPTION
This PR fixes path issues caused by `site.baseurl`. Since `site.baseurl` resolves to `/` it seemed sensible to create a replacement variable for it which hopefully avoids any undesired behaviour with `site.baseurl`.

What do you think @gnhn ? It is weird that `site.baseurl` behaves fine in the iOS repository but this certainly fixes it locally?


<img width="1422" alt="Screenshot 2022-05-25 at 11 40 29" src="https://user-images.githubusercontent.com/30452349/170244061-b435856f-4877-4008-8e6d-d79f64eef611.png">