### PR TITLE
fix(): Video Ad crashes when the Warning dialog is accessed

### DIFF
--- a/superawesome-base/src/main/java/tv/superawesome/lib/saclosewarning/SACloseWarning.java
+++ b/superawesome-base/src/main/java/tv/superawesome/lib/saclosewarning/SACloseWarning.java
@@ -1,5 +1,8 @@
 package tv.superawesome.lib.saclosewarning;
 
+import static android.os.Build.VERSION;
+import static android.os.Build.VERSION_CODES;
+
 import android.app.AlertDialog;
 import android.content.Context;
 
@@ -13,12 +16,12 @@ public class SACloseWarning {
 
     private static SACloseWarning.Interface listener;
 
-    public static void show(final Context c) {
+    public static void show(final Context context) {
         final AlertDialog.Builder alert;
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP_MR1) {
-            alert = new AlertDialog.Builder(c, android.R.style.Theme_DeviceDefault_Dialog_Alert);
+        if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP_MR1) {
+            alert = new AlertDialog.Builder(context, android.R.style.Theme_DeviceDefault_Dialog_Alert);
         } else {
-            alert = new AlertDialog.Builder(c);
+            alert = new AlertDialog.Builder(context);
         }
         alert.setTitle(AlertTitle);
         alert.setCancelable(false);
@@ -44,7 +47,9 @@ public class SACloseWarning {
 
     public static void close() {
         if (dialog != null) {
-            dialog.cancel();
+            if (dialog.isShowing()) {
+                dialog.cancel();
+            }
             dialog = null;
         }
     }

--- a/superawesome-base/src/main/java/tv/superawesome/lib/saparentalgate/SAParentalGate.java
+++ b/superawesome-base/src/main/java/tv/superawesome/lib/saparentalgate/SAParentalGate.java
@@ -123,7 +123,10 @@ public class SAParentalGate {
      */
     public static void close () {
         if (dialog != null) {
-            dialog.cancel();
+            if(dialog.isShowing()) {
+                dialog.cancel();
+            }
+            dialog = null;
         }
     }
 

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoActivity.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoActivity.java
@@ -146,6 +146,13 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
     }
 
     @Override
+    protected void onDestroy() {
+        SAParentalGate.close();
+        SACloseWarning.close();
+        super.onDestroy();
+    }
+
+    @Override
     protected void onPause() {
         super.onPause();
         control.pause();


### PR DESCRIPTION
fix(): Video Ad crashes when the Warning dialog is accessed even after the activity is closed

Main cause: When the system decides to destroy activity in the background and if the close warning dialog is present, then it causes this kind of crashes. 

P.s.: Need to release a new unity version as well.