### PR TITLE
Build/circle ci semantic release dry run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ workflows:
           filters:
             tags:
               ignore: /^v.*/
-      -semantic_release_dry_run:
+      - semantic_release_dry_run:
           context: MOBILE_ANDROID_SDKS
           requires:
             - test_superawesome_base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
   semantic_release_dry_run:
     <<: *android_config
     environment:
-      SA_SEMANTIC_RELEASE_RUN_BRANCH: ${CIRCLE_BRANCH}
+      SA_SEMANTIC_RELEASE_RUN_BRANCH: develop
     steps:
       - checkout
       - *generate_github_token
@@ -57,7 +57,7 @@ jobs:
           name: Check semantic release version
           command: |
             git clone https://x-access-token:${GITHUB_TOKEN}@github.com/SuperAwesomeLTD/sa-continuous-integration.git "${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}"
-            ${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}/semantic-release/semantic-release.sh --dry-run --branches ${CIRCLE_BRANCH}
+            ${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}/semantic-release/semantic-release.sh --dry-run
 
   semantic_release:
     <<: *android_config
@@ -180,6 +180,9 @@ workflows:
           context: MOBILE_ANDROID_SDKS
           requires:
             - test_superawesome_base
+          filters:
+            branches:
+              only: develop          
       - approve_dry_run_output:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           name: Check semantic release version
           command: |
             git clone https://x-access-token:${GITHUB_TOKEN}@github.com/SuperAwesomeLTD/sa-continuous-integration.git "${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}"
-            ${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}/semantic-release/semantic-release.sh --dry-run --branches ${CIRCLE_BRANCH}
+            ${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}/semantic-release/semantic-release.sh --dry-run
 
   semantic_release:
     <<: *android_config
@@ -180,6 +180,9 @@ workflows:
           context: MOBILE_ANDROID_SDKS
           requires:
             - test_superawesome_base
+          filters:
+            branches:
+              only: develop
       - approve_dry_run_output:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,19 @@ jobs:
           command: find $PWD/superawesome-base/build/test-results/testDebugUnitTest -name '*.xml' -exec cp {} ${PWD}/temp_files/test-results/debug \;
       - store_test_results:
           path: temp_files/test-results
+  
+  semantic_release_dry_run:
+    <<: *android_config
+    environment:
+      SA_SEMANTIC_RELEASE_RUN_BRANCH: develop
+    steps:
+      - checkout
+      - *generate_github_token
+      - run:
+          name: Check semantic release version
+          command: |
+            git clone https://x-access-token:${GITHUB_TOKEN}@github.com/SuperAwesomeLTD/sa-continuous-integration.git "${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}"
+            ${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}/semantic-release/semantic-release.sh --dry-run --branches ${CIRCLE_BRANCH}
 
   semantic_release:
     <<: *android_config
@@ -163,17 +176,21 @@ workflows:
           filters:
             tags:
               ignore: /^v.*/
-      - approve_release:
-          type: approval
+      -semantic_release_dry_run:
+          context: MOBILE_ANDROID_SDKS
           requires:
             - test_superawesome_base
+      - approve_dry_run_output:
+          type: approval
+          requires:
+            - semantic_release_dry_run
           filters:
             branches:
               only: develop
       - prep_deploy:
           context: MOBILE_ANDROID_APPS
           requires:
-            - approve_release
+            - approve_dry_run_output
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
   semantic_release_dry_run:
     <<: *android_config
     environment:
-      SA_SEMANTIC_RELEASE_RUN_BRANCH: develop
+      SA_SEMANTIC_RELEASE_RUN_BRANCH: ${CIRCLE_BRANCH}
     steps:
       - checkout
       - *generate_github_token
@@ -57,7 +57,7 @@ jobs:
           name: Check semantic release version
           command: |
             git clone https://x-access-token:${GITHUB_TOKEN}@github.com/SuperAwesomeLTD/sa-continuous-integration.git "${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}"
-            ${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}/semantic-release/semantic-release.sh --dry-run
+            ${SA_PATH_TO_CONTINUOUS_INTEGRATION_REPO}/semantic-release/semantic-release.sh --dry-run --branches ${CIRCLE_BRANCH}
 
   semantic_release:
     <<: *android_config
@@ -180,9 +180,6 @@ workflows:
           context: MOBILE_ANDROID_SDKS
           requires:
             - test_superawesome_base
-          filters:
-            branches:
-              only: develop
       - approve_dry_run_output:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ workflows:
           filters:
             branches:
               only: develop          
-      - approve_dry_run_output:
+      - approve_dry_run_and_release:
           type: approval
           requires:
             - semantic_release_dry_run
@@ -193,7 +193,7 @@ workflows:
       - prep_deploy:
           context: MOBILE_ANDROID_APPS
           requires:
-            - approve_dry_run_output
+            - approve_dry_run_and_release
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
This PR adds a semantic release "dry run" step to our circleCI build & release process. It is set up to only run on `develop` so that we can ensure we are checking the semantic release version of the most up-to-date code before we approve to release.

The dry run will analyse the commits since the last released version and output the changelog and expected version to be released, or whether there just won't be a release. The dry run flag ensures we do not actually release the version outputted. This will allow us to double-check a version which will be released, or make a commit to ensure a particular release is made if the dry run says nothing will be released yet.

For context:
- semantic-release docs: https://www.businesswire.com/news/home/20220809005530/en/AppLovin-Submits-a-Compelling-Non-Binding-Proposal-to-Combine-with-Unity
- KWS PR adding similar implementation: https://github.com/SuperAwesomeLTD/freekws-nestjs-http-interceptors/pull/128/files
- Example semantic_release dry-run (KWS): https://app.circleci.com/pipelines/github/SuperAwesomeLTD/freekws-nestjs-http-interceptors/1050/workflows/5805ca19-2cb1-4c5a-a31c-cd0bef6e678e/jobs/3624