### PR TITLE
Chore/aag 2255 safe ad logo appearing multiple times

### DIFF
--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/AdModels.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/AdModels.kt
@@ -20,7 +20,6 @@ data class Ad(
     @SerialName("safe_ad_approved") val safeAdApproved: Boolean,
     @SerialName("show_padlock") val showPadlock: Boolean,
     @SerialName("line_item_id") val lineItemId: Int,
-    @SerialName("ksfRequest") val ksfRequest: String,
     val test: Boolean,
     val app: Int,
     val device: String,

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/AdModels.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/AdModels.kt
@@ -2,13 +2,12 @@
 
 package tv.superawesome.sdk.publisher.common.models
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
+import kotlinx.serialization.*
+import tv.superawesome.sdk.publisher.common.serializers.AdSerializer
 
 const val CPI_CAMPAIGN_ID = 1
 
-@Serializable
+@Serializable(with = AdSerializer::class)
 data class Ad(
     val advertiserId: Int? = null,
     val publisherId: Int,
@@ -21,6 +20,7 @@ data class Ad(
     @SerialName("safe_ad_approved") val safeAdApproved: Boolean,
     @SerialName("show_padlock") val showPadlock: Boolean,
     @SerialName("line_item_id") val lineItemId: Int,
+    @SerialName("ksfRequest") val ksfRequest: String,
     val test: Boolean,
     val app: Int,
     val device: String,

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/CreativeModels.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/CreativeModels.kt
@@ -11,7 +11,8 @@ data class Creative(
     @SerialName("click_url") val clickUrl: String? = null,
     val details: CreativeDetail,
     val bumper: Boolean? = null,
-    val referral: CreativeReferral? = null
+    val referral: CreativeReferral? = null,
+    val isKSF: Boolean = false
 )
 
 @Serializable

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/serializers/AdSerializer.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/serializers/AdSerializer.kt
@@ -10,129 +10,129 @@ import tv.superawesome.sdk.publisher.common.models.Creative
 import tv.superawesome.sdk.publisher.common.models.CreativeDetail
 import tv.superawesome.sdk.publisher.common.models.CreativeFormatType
 
-class AdSerializer: KSerializer<Ad> {
+class AdSerializer : KSerializer<Ad> {
 
-	override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Ad") {
-		element<Int?>("advertiserId")
-		element<Int>("publisherId")
-		element<Float>("moat")
-		element<Boolean>("is_fill")
-		element<Boolean>("is_fallback")
-		element<Int>("campaign_type")
-		element<Int>("campaign_id")
-		element<Boolean>("is_house")
-		element<Boolean>("safe_ad_approved")
-		element<Boolean>("show_padlock")
-		element<Int>("line_item_id")
-		element<Boolean>("test")
-		element<Int>("app")
-		element<String>("device")
-		element<Creative>("creative")
-	}
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Ad") {
+        element<Int?>("advertiserId")
+        element<Int>("publisherId")
+        element<Float>("moat")
+        element<Boolean>("is_fill")
+        element<Boolean>("is_fallback")
+        element<Int>("campaign_type")
+        element<Int>("campaign_id")
+        element<Boolean>("is_house")
+        element<Boolean>("safe_ad_approved")
+        element<Boolean>("show_padlock")
+        element<Int>("line_item_id")
+        element<Boolean>("test")
+        element<Int>("app")
+        element<String>("device")
+        element<Creative>("creative")
+    }
 
-	override fun serialize(encoder: Encoder, value: Ad)
-	{
-		encoder.encodeStructure(descriptor) {
+    override fun serialize(encoder: Encoder, value: Ad) {
+        encoder.encodeStructure(descriptor) {
 
-			// Optionals
-			value.advertiserId?.let { encodeIntElement(descriptor, 0, value.advertiserId) }
+            // Optionals
+            value.advertiserId?.let { encodeIntElement(descriptor, 0, value.advertiserId) }
 
-			// Non-Optionals
-			encodeIntElement(descriptor, 1, value.publisherId)
-			encodeFloatElement(descriptor, 2, value.moat)
-			encodeBooleanElement(descriptor, 3, value.isFill)
-			encodeBooleanElement(descriptor, 4, value.isFallback)
-			encodeIntElement(descriptor, 5, value.campaignType)
-			encodeIntElement(descriptor, 6, value.campaignId)
-			encodeBooleanElement(descriptor, 7, value.isHouse)
-			encodeBooleanElement(descriptor, 8, value.safeAdApproved)
-			encodeBooleanElement(descriptor, 9, value.showPadlock)
-			encodeIntElement(descriptor, 10, value.lineItemId)
-			encodeBooleanElement(descriptor, 11, value.test)
-			encodeIntElement(descriptor, 12, value.app)
-			encodeStringElement(descriptor, 13, value.device)
+            // Non-Optionals
+            encodeIntElement(descriptor, 1, value.publisherId)
+            encodeFloatElement(descriptor, 2, value.moat)
+            encodeBooleanElement(descriptor, 3, value.isFill)
+            encodeBooleanElement(descriptor, 4, value.isFallback)
+            encodeIntElement(descriptor, 5, value.campaignType)
+            encodeIntElement(descriptor, 6, value.campaignId)
+            encodeBooleanElement(descriptor, 7, value.isHouse)
+            encodeBooleanElement(descriptor, 8, value.safeAdApproved)
+            encodeBooleanElement(descriptor, 9, value.showPadlock)
+            encodeIntElement(descriptor, 10, value.lineItemId)
+            encodeBooleanElement(descriptor, 11, value.test)
+            encodeIntElement(descriptor, 12, value.app)
+            encodeStringElement(descriptor, 13, value.device)
 
-			// Custom Types
-			encodeSerializableElement(descriptor, index = 14, Creative.serializer(), value.creative)
-		}
-	}
+            // Custom Types
+            encodeSerializableElement(descriptor, index = 14, Creative.serializer(), value.creative)
+        }
+    }
 
-	override fun deserialize(decoder: Decoder): Ad =
-		decoder.decodeStructure(descriptor) {
+    override fun deserialize(decoder: Decoder): Ad =
+        decoder.decodeStructure(descriptor) {
 
-			var advertiserId: Int? = null
-			var publisherId = 0
-			var moat = 0.0f
-			var isFill = false
-			var isFallback = false
-			var campaignType = 0
-			var campaignId = 0
-			var isHouse = false
-			var safeAdApproved = false
-			var showPadlock = false
-			var lineItemId = 0
-			var test = false
-			var app = 0
-			var device = ""
-			var creative = Creative(
-				0,
-				null,
-				CreativeFormatType.ImageWithLink,
-				null,
-				CreativeDetail(
-					null,
-					null,
-					null,
-					"",
-					null,
-					0,
-					0,
-					0,
-					null
-				)
-			)
+            var advertiserId: Int? = null
+            var publisherId = 0
+            var moat = 0.0f
+            var isFill = false
+            var isFallback = false
+            var campaignType = 0
+            var campaignId = 0
+            var isHouse = false
+            var safeAdApproved = false
+            var showPadlock = false
+            var lineItemId = 0
+            var test = false
+            var app = 0
+            var device = ""
+            var creative = Creative(
+                0,
+                null,
+                CreativeFormatType.ImageWithLink,
+                null,
+                CreativeDetail(
+                    null,
+                    null,
+                    null,
+                    "",
+                    null,
+                    0,
+                    0,
+                    0,
+                    null
+                )
+            )
 
-			while (true) {
-				when (val index = decodeElementIndex(descriptor)) {
-					0 -> advertiserId = decodeIntElement(descriptor, 0)
-					1 -> publisherId = decodeIntElement(descriptor, 1)
-					2 -> moat = decodeFloatElement(descriptor, 2)
-					3 -> isFill = decodeBooleanElement(descriptor, 3)
-					4 -> isFallback = decodeBooleanElement(descriptor, 4)
-					5 -> campaignType = decodeIntElement(descriptor, 5)
-					6 -> campaignId = decodeIntElement(descriptor, 6)
-					7 -> isHouse = decodeBooleanElement(descriptor, 7)
-					8 -> safeAdApproved = decodeBooleanElement(descriptor, 8)
-					9 -> showPadlock = decodeBooleanElement(descriptor, 9)
-					10 -> lineItemId = decodeIntElement(descriptor, 10)
-					11 -> test = decodeBooleanElement(descriptor, 11)
-					12 -> app = decodeIntElement(descriptor, 12)
-					13 -> device = decodeStringElement(descriptor, 13)
-					14 -> creative = decodeSerializableElement(descriptor, 14, Creative.serializer())
-					CompositeDecoder.DECODE_DONE -> break
-					else -> error("Unexpected index: $index")
-				}
-			}
+            while (true) {
+                when (val index = decodeElementIndex(descriptor)) {
+                    0 -> advertiserId = decodeIntElement(descriptor, 0)
+                    1 -> publisherId = decodeIntElement(descriptor, 1)
+                    2 -> moat = decodeFloatElement(descriptor, 2)
+                    3 -> isFill = decodeBooleanElement(descriptor, 3)
+                    4 -> isFallback = decodeBooleanElement(descriptor, 4)
+                    5 -> campaignType = decodeIntElement(descriptor, 5)
+                    6 -> campaignId = decodeIntElement(descriptor, 6)
+                    7 -> isHouse = decodeBooleanElement(descriptor, 7)
+                    8 -> safeAdApproved = decodeBooleanElement(descriptor, 8)
+                    9 -> showPadlock = decodeBooleanElement(descriptor, 9)
+                    10 -> lineItemId = decodeIntElement(descriptor, 10)
+                    11 -> test = decodeBooleanElement(descriptor, 11)
+                    12 -> app = decodeIntElement(descriptor, 12)
+                    13 -> device = decodeStringElement(descriptor, 13)
+                    14 -> creative = decodeSerializableElement(descriptor, 14, Creative.serializer())
+                    CompositeDecoder.DECODE_DONE -> break
+                    else -> error("Unexpected index: $index")
+                }
+            }
 
-			if (showPadlock && creative.isKSF) {
-				showPadlock = false
-			}
+            if (showPadlock && creative.isKSF) {
+                showPadlock = false
+            }
 
-			Ad(advertiserId,
-				publisherId,
-				moat,
-				isFill,
-				isFallback,
-				campaignType,
-				campaignId,
-				isHouse,
-				safeAdApproved,
-				showPadlock,
-				lineItemId,
-				test,
-				app,
-				device,
-				creative
-			)
-		}
+            Ad(
+                advertiserId,
+                publisherId,
+                moat,
+                isFill,
+                isFallback,
+                campaignType,
+                campaignId,
+                isHouse,
+                safeAdApproved,
+                showPadlock,
+                lineItemId,
+                test,
+                app,
+                device,
+                creative
+            )
+        }
 }

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/serializers/AdSerializer.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/serializers/AdSerializer.kt
@@ -118,8 +118,7 @@ class AdSerializer: KSerializer<Ad> {
 				showPadlock = false
 			}
 
-			Ad(
-				advertiserId,
+			Ad(advertiserId,
 				publisherId,
 				moat,
 				isFill,

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/serializers/AdSerializer.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/serializers/AdSerializer.kt
@@ -1,0 +1,146 @@
+package tv.superawesome.sdk.publisher.common.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.element
+import kotlinx.serialization.encoding.*
+import tv.superawesome.sdk.publisher.common.models.Ad
+import tv.superawesome.sdk.publisher.common.models.Creative
+import tv.superawesome.sdk.publisher.common.models.CreativeDetail
+import tv.superawesome.sdk.publisher.common.models.CreativeFormatType
+
+class AdSerializer: KSerializer<Ad> {
+
+	override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Ad") {
+		element<Int?>("advertiserId")
+		element<Int>("publisherId")
+		element<Float>("moat")
+		element<Boolean>("is_fill")
+		element<Boolean>("is_fallback")
+		element<Int>("campaign_type")
+		element<Int>("campaign_id")
+		element<Boolean>("is_house")
+		element<Boolean>("safe_ad_approved")
+		element<String>("ksfRequest")
+		element<Boolean>("show_padlock")
+		element<Int>("line_item_id")
+		element<Boolean>("test")
+		element<Int>("app")
+		element<String>("device")
+		element<Creative>("creative")
+	}
+
+	override fun serialize(encoder: Encoder, value: Ad)
+	{
+		encoder.encodeStructure(descriptor) {
+
+			// Optionals
+			value.advertiserId?.let { encodeIntElement(descriptor, 0, value.advertiserId) }
+
+			// Non-Optionals
+			encodeIntElement(descriptor, 1, value.publisherId)
+			encodeFloatElement(descriptor, 2, value.moat)
+			encodeBooleanElement(descriptor, 3, value.isFill)
+			encodeBooleanElement(descriptor, 4, value.isFallback)
+			encodeIntElement(descriptor, 5, value.campaignType)
+			encodeIntElement(descriptor, 6, value.campaignId)
+			encodeBooleanElement(descriptor, 7, value.isHouse)
+			encodeStringElement(descriptor, 8, value.ksfRequest)
+			encodeBooleanElement(descriptor, 9, value.safeAdApproved)
+
+			if (value.showPadlock && value.ksfRequest != null && value.ksfRequest.isNotEmpty()) {
+				encodeBooleanElement(descriptor, 10, false)
+			} else {
+				encodeBooleanElement(descriptor, 10, value.showPadlock)
+			}
+
+			encodeIntElement(descriptor, 11, value.lineItemId)
+			encodeBooleanElement(descriptor, 12, value.test)
+			encodeIntElement(descriptor, 13, value.app)
+			encodeStringElement(descriptor, 14, value.device)
+
+			// Custom Types
+			encodeSerializableElement(Creative.serializer().descriptor, index = 15, Creative.serializer(), value.creative)
+		}
+	}
+
+	override fun deserialize(decoder: Decoder): Ad =
+		decoder.decodeStructure(descriptor) {
+
+			var advertiserId: Int? = null
+			var publisherId = 0
+			var moat = 0.0f
+			var isFill = false
+			var isFallback = false
+			var campaignType = 0
+			var campaignId = 0
+			var isHouse = false
+			var safeAdApproved = false
+			var ksfRequest = ""
+			var showPadlock = false
+			var lineItemId = 0
+			var test = false
+			var app = 0
+			var device = ""
+			var creative = Creative(
+				0,
+				null,
+				CreativeFormatType.ImageWithLink,
+				null,
+				CreativeDetail(
+					null,
+					null,
+					null,
+					"",
+					null,
+					0,
+					0,
+					0,
+					null
+				)
+			)
+
+			while (true) {
+				when (val index = decodeElementIndex(descriptor)) {
+					0 -> advertiserId = decodeIntElement(descriptor, 0)
+					1 -> publisherId = decodeIntElement(descriptor, 1)
+					2 -> moat = decodeFloatElement(descriptor, 2)
+					3 -> isFill = decodeBooleanElement(descriptor, 3)
+					4 -> isFallback = decodeBooleanElement(descriptor, 4)
+					5 -> campaignType = decodeIntElement(descriptor, 5)
+					6 -> campaignId = decodeIntElement(descriptor, 6)
+					7 -> isHouse = decodeBooleanElement(descriptor, 7)
+					8 -> safeAdApproved = decodeBooleanElement(descriptor, 8)
+					9 -> ksfRequest = decodeStringElement(descriptor, 9)
+					10 -> showPadlock = decodeBooleanElement(descriptor, 10)
+					11 -> lineItemId = decodeIntElement(descriptor, 11)
+					12 -> test = decodeBooleanElement(descriptor, 12)
+					13 -> app = decodeIntElement(descriptor, 13)
+					14 -> device = decodeStringElement(descriptor, 14)
+					15 -> creative = decodeSerializableElement(descriptor, 15, Creative.serializer())
+					CompositeDecoder.DECODE_DONE -> break
+					else -> error("Unexpected index: $index")
+				}
+			}
+
+			Ad(
+				advertiserId,
+				publisherId,
+				moat,
+				isFill,
+				isFallback,
+				campaignType,
+				campaignId,
+				isHouse,
+				safeAdApproved,
+				showPadlock,
+				lineItemId,
+				ksfRequest,
+				test,
+				app,
+				device,
+				creative
+			)
+		}
+}

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/serializers/AdSerializer.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/serializers/AdSerializer.kt
@@ -22,7 +22,6 @@ class AdSerializer: KSerializer<Ad> {
 		element<Int>("campaign_id")
 		element<Boolean>("is_house")
 		element<Boolean>("safe_ad_approved")
-		element<String>("ksfRequest")
 		element<Boolean>("show_padlock")
 		element<Int>("line_item_id")
 		element<Boolean>("test")
@@ -46,22 +45,15 @@ class AdSerializer: KSerializer<Ad> {
 			encodeIntElement(descriptor, 5, value.campaignType)
 			encodeIntElement(descriptor, 6, value.campaignId)
 			encodeBooleanElement(descriptor, 7, value.isHouse)
-			encodeStringElement(descriptor, 8, value.ksfRequest)
-			encodeBooleanElement(descriptor, 9, value.safeAdApproved)
-
-			if (value.showPadlock && value.ksfRequest != null && value.ksfRequest.isNotEmpty()) {
-				encodeBooleanElement(descriptor, 10, false)
-			} else {
-				encodeBooleanElement(descriptor, 10, value.showPadlock)
-			}
-
-			encodeIntElement(descriptor, 11, value.lineItemId)
-			encodeBooleanElement(descriptor, 12, value.test)
-			encodeIntElement(descriptor, 13, value.app)
-			encodeStringElement(descriptor, 14, value.device)
+			encodeBooleanElement(descriptor, 8, value.safeAdApproved)
+			encodeBooleanElement(descriptor, 9, value.showPadlock)
+			encodeIntElement(descriptor, 10, value.lineItemId)
+			encodeBooleanElement(descriptor, 11, value.test)
+			encodeIntElement(descriptor, 12, value.app)
+			encodeStringElement(descriptor, 13, value.device)
 
 			// Custom Types
-			encodeSerializableElement(Creative.serializer().descriptor, index = 15, Creative.serializer(), value.creative)
+			encodeSerializableElement(Creative.serializer().descriptor, index = 14, Creative.serializer(), value.creative)
 		}
 	}
 
@@ -77,7 +69,6 @@ class AdSerializer: KSerializer<Ad> {
 			var campaignId = 0
 			var isHouse = false
 			var safeAdApproved = false
-			var ksfRequest = ""
 			var showPadlock = false
 			var lineItemId = 0
 			var test = false
@@ -112,16 +103,19 @@ class AdSerializer: KSerializer<Ad> {
 					6 -> campaignId = decodeIntElement(descriptor, 6)
 					7 -> isHouse = decodeBooleanElement(descriptor, 7)
 					8 -> safeAdApproved = decodeBooleanElement(descriptor, 8)
-					9 -> ksfRequest = decodeStringElement(descriptor, 9)
-					10 -> showPadlock = decodeBooleanElement(descriptor, 10)
-					11 -> lineItemId = decodeIntElement(descriptor, 11)
-					12 -> test = decodeBooleanElement(descriptor, 12)
-					13 -> app = decodeIntElement(descriptor, 13)
-					14 -> device = decodeStringElement(descriptor, 14)
-					15 -> creative = decodeSerializableElement(descriptor, 15, Creative.serializer())
+					9 -> showPadlock = decodeBooleanElement(descriptor, 9)
+					10 -> lineItemId = decodeIntElement(descriptor, 10)
+					11 -> test = decodeBooleanElement(descriptor, 11)
+					12 -> app = decodeIntElement(descriptor, 12)
+					13 -> device = decodeStringElement(descriptor, 13)
+					14 -> creative = decodeSerializableElement(descriptor, 14, Creative.serializer())
 					CompositeDecoder.DECODE_DONE -> break
 					else -> error("Unexpected index: $index")
 				}
+			}
+
+			if (showPadlock && creative.isKSF) {
+				showPadlock = false
 			}
 
 			Ad(
@@ -136,7 +130,6 @@ class AdSerializer: KSerializer<Ad> {
 				safeAdApproved,
 				showPadlock,
 				lineItemId,
-				ksfRequest,
 				test,
 				app,
 				device,

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/serializers/AdSerializer.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/serializers/AdSerializer.kt
@@ -53,7 +53,7 @@ class AdSerializer: KSerializer<Ad> {
 			encodeStringElement(descriptor, 13, value.device)
 
 			// Custom Types
-			encodeSerializableElement(Creative.serializer().descriptor, index = 14, Creative.serializer(), value.creative)
+			encodeSerializableElement(descriptor, index = 14, Creative.serializer(), value.creative)
 		}
 	}
 

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/AdSerializerTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/AdSerializerTest.kt
@@ -32,7 +32,7 @@ class AdSerializerTest {
 		assertEquals(0.1f, ad.moat)
 		assertEquals(true, ad.isHouse)
 		assertEquals(true, ad.safeAdApproved)
-		// showPadlock is false although it is true in the response as isKSF is true
+		// showPadlock is false although it is true in the response as 'isKSF' is true
 		assertEquals(false, ad.showPadlock)
 		assertEquals(176805, ad.lineItemId)
 		assertEquals(false, ad.test)

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/AdSerializerTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/AdSerializerTest.kt
@@ -1,0 +1,54 @@
+package tv.superawesome.sdk.publisher.common.components
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import tv.superawesome.sdk.publisher.common.models.Ad
+import tv.superawesome.sdk.publisher.common.models.CreativeFormatType
+import tv.superawesome.sdk.publisher.common.testutil.ResourceReader
+import kotlin.test.assertEquals
+
+class AdSerializerTest {
+
+	private val json = Json { ignoreUnknownKeys = true }
+
+	@Test
+	fun `test_decoding_successfully`() = runBlocking {
+
+		val file = ResourceReader.readResource("mock_ksf_interstitial.json")
+		val ad = json.decodeFromString(Ad.serializer(), file)
+		val creative = ad.creative
+		val creativeDetails = ad.creative.details
+
+		assertEquals(4, ad.advertiserId)
+		assertEquals(4, ad.publisherId)
+		assertEquals(false, ad.isFill)
+		assertEquals(false, ad.isFallback)
+		assertEquals(0.1f, ad.moat)
+		assertEquals(true, ad.isHouse)
+		assertEquals(true, ad.safeAdApproved)
+		assertEquals(false, ad.showPadlock)
+		assertEquals(176805, ad.lineItemId)
+		assertEquals(false, ad.test)
+		assertEquals(41037, ad.app)
+		assertEquals("phone", ad.device)
+
+		// Creative
+		assertEquals(499595, creative.id)
+		assertEquals("QA_SDK_Interstitial_KSF_Latest_Test", creative.name)
+		assertEquals(CreativeFormatType.Tag, creative.format)
+		assertEquals("undefined", creative.clickUrl)
+		assertEquals(false, creative.bumper)
+		assertEquals(true, creative.isKSF)
+
+		// Creative Detail
+		assertEquals("mobile_display", creativeDetails.placementFormat)
+		assertEquals(
+			"<html>\n    <header>\n        <meta name='viewport' content='width=device-width'/>\n        <style>html, body, div { margin: 0px; padding: 0px; } html, body { width: 100%; height: 100%; }</style>\n    </header>\n    <body><script type=\"text/javascript\" src=\"https://eu-west-1-ads.superawesome.tv/v2/ad.js?placement=84799&lineItemId=176805&creativeId=499595&sdkVersion=android_8.3.6_admob&rnd=71922ddc-06aa-4f56-9496-4ae0af720b16&bundle=tv.superawesome.demoapp&dauid=580289352&ct=2&lang=en_US&device=phone&pos=7&timestamp=_TIMESTAMP_&skip=1&playbackmethod=5&startdelay=0&instl=1&isProgrammatic=true\"></script></body>\n    </html>",
+			creativeDetails.tag
+		)
+		assertEquals(320, creativeDetails.width)
+		assertEquals(480, creativeDetails.height)
+		assertEquals(0, creativeDetails.duration)
+	}
+}

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/AdSerializerTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/AdSerializerTest.kt
@@ -3,20 +3,23 @@ package tv.superawesome.sdk.publisher.common.components
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import org.junit.Test
-import tv.superawesome.sdk.publisher.common.models.Ad
-import tv.superawesome.sdk.publisher.common.models.CreativeFormatType
+import tv.superawesome.sdk.publisher.common.models.*
+import tv.superawesome.sdk.publisher.common.testutil.FakeFactory
 import tv.superawesome.sdk.publisher.common.testutil.ResourceReader
 import kotlin.test.assertEquals
 
 class AdSerializerTest {
 
-	private val json = Json { ignoreUnknownKeys = true }
+	private val json = Json {
+		ignoreUnknownKeys = true
+		useAlternativeNames = false
+	}
 
 	@Test
 	fun `test_decoding_successfully`() = runBlocking {
 
-		val file = ResourceReader.readResource("mock_ksf_interstitial.json")
-		val ad = json.decodeFromString(Ad.serializer(), file)
+		val jsonFile = ResourceReader.readResource("mock_ksf_interstitial.json")
+		val ad = json.decodeFromString(Ad.serializer(), jsonFile)
 		val creative = ad.creative
 		val creativeDetails = ad.creative.details
 
@@ -24,6 +27,8 @@ class AdSerializerTest {
 		assertEquals(4, ad.publisherId)
 		assertEquals(false, ad.isFill)
 		assertEquals(false, ad.isFallback)
+		assertEquals(0, ad.campaignType)
+		assertEquals(49137, ad.campaignId)
 		assertEquals(0.1f, ad.moat)
 		assertEquals(true, ad.isHouse)
 		assertEquals(true, ad.safeAdApproved)
@@ -50,5 +55,47 @@ class AdSerializerTest {
 		assertEquals(320, creativeDetails.width)
 		assertEquals(480, creativeDetails.height)
 		assertEquals(0, creativeDetails.duration)
+	}
+
+	@Test
+	fun `test_encoding_successfully`() = runBlocking {
+
+		val jsonFile = ResourceReader.readResource("mock_ksf_interstitial.json")
+
+		val ad = Ad(
+			advertiserId = 4,
+			publisherId = 4,
+			moat = 0.1f,
+			isFill = false,
+			isFallback = false,
+			campaignType = 0,
+			campaignId = 49137,
+			isHouse = true,
+			safeAdApproved = true,
+			showPadlock = true,
+			lineItemId = 176805,
+			test = false,
+			app = 41037,
+			device = "phone",
+			creative = Creative(
+				id = 499595,
+				format = CreativeFormatType.Tag,
+				referral = CreativeReferral(),
+				details = CreativeDetail(
+					url = FakeFactory.exampleUrl,
+					video = "",
+					placementFormat = "mobile_display",
+					width = 320,
+					height = 480,
+					duration = 0,
+					image = FakeFactory.exampleUrl,
+					vast = ""
+				)
+			)
+		)
+
+		val encodedAd = json.encodeToString(Ad.serializer(), ad)
+
+		assertEquals(jsonFile, encodedAd)
 	}
 }

--- a/superawesome-common/src/test/resources/mock_ksf_interstitial.json
+++ b/superawesome-common/src/test/resources/mock_ksf_interstitial.json
@@ -1,0 +1,53 @@
+{
+  "advertiserId": 4,
+  "publisherId": 4,
+  "creative": {
+    "id": 499595,
+    "version": 1,
+    "name": "QA_SDK_Interstitial_KSF_Latest_Test",
+    "format": "tag",
+    "formatId": 12,
+    "cpms": {
+      "default": "0"
+    },
+    "impressionUrls": [],
+    "freqCappingLimit": 0,
+    "details": {
+      "placement_format": "mobile_display",
+      "tag": "<html>\n    <header>\n        <meta name='viewport' content='width=device-width'/>\n        <style>html, body, div { margin: 0px; padding: 0px; } html, body { width: 100%; height: 100%; }</style>\n    </header>\n    <body><script type=\"text/javascript\" src=\"https://eu-west-1-ads.superawesome.tv/v2/ad.js?placement=84799&lineItemId=176805&creativeId=499595&sdkVersion=android_8.3.6_admob&rnd=71922ddc-06aa-4f56-9496-4ae0af720b16&bundle=tv.superawesome.demoapp&dauid=580289352&ct=2&lang=en_US&device=phone&pos=7&timestamp=_TIMESTAMP_&skip=1&playbackmethod=5&startdelay=0&instl=1&isProgrammatic=true\"></script></body>\n    </html>",
+      "width": 320,
+      "height": 480,
+      "duration": 0
+    },
+    "approved": 1,
+    "live": true,
+    "osTarget": [],
+    "browserTarget": [],
+    "browserTargetExclude": false,
+    "directProgrammatic": true,
+    "paused": false,
+    "approvedImpressions": [],
+    "approvedClickTracking": [],
+    "approvedEvents": {},
+    "bumper": false,
+    "attributionType": 1,
+    "vpaid": false,
+    "click_url": "undefined",
+    "isKSF": true
+  },
+  "is_fill": false,
+  "is_fallback": false,
+  "moat": 0.1,
+  "is_house": true,
+  "safe_ad_approved": true,
+  "show_padlock": true,
+  "campaign_type": 0,
+  "line_item_id": 176805,
+  "campaign_id": 49137,
+  "test": false,
+  "app": 41037,
+  "device": "phone",
+  "aua": "eyJhbGciOiJIUzI1NiJ9.TW96aWxsYS81LjAgKExpbnV4OyBBbmRyb2lkIDEwKSBBcHBsZVdlYktpdC81MzcuMzYgKEtIVE1MLCBsaWtlIEdlY2tvKSBDaHJvbWUvODMuMC40MTAzLjk2IE1vYmlsZSBTYWZhcmkvNTM3LjM2.I_tn7-WYamd5_dlbbCVEZM0gj0A0s3akPbjkX2p2v6E",
+  "tip": "eyJhbGciOiJIUzI1NiJ9.ODEuMTEwLjI0OS4w.JID_ookEWOeYqark_ZJ8RGhOQaLYYq2UodGzzmzy0oQ",
+  "ksfRequest": "https://ksf-api.superawesome.tv/v1/render?data=%7B%22aaCreativeData%22%3A%7B%22formatId%22%3A12%2C%22format%22%3A%22tag%22%2C%22placementType%22%3A%22directProgrammatic%22%2C%22parentCreativeData%22%3A%7B%22thirdPartyCreativeId%22%3A499595%2C%22thirdPartyLineItemId%22%3A176805%2C%22thirdPartyCampaignId%22%3A49137%7D%7D%2C%22vpaid%22%3Afalse%2C%22renderHeaders%22%3A%7B%22user-agent%22%3A%22Mozilla%2F5.0%20(Linux%3B%20Android%2010)%20AppleWebKit%2F537.36%20(KHTML%2C%20like%20Gecko)%20Chrome%2F83.0.4103.96%20Mobile%20Safari%2F537.36%22%2C%22x-forwarded-for%22%3A%2281.110.249.0%22%7D%2C%22recordDataID%22%3A%2237e67240-ea0c-4dfd-b6bf-50a64e4087cd%22%7D"
+}

--- a/superawesome-common/src/test/resources/mock_ksf_interstitial.json
+++ b/superawesome-common/src/test/resources/mock_ksf_interstitial.json
@@ -14,7 +14,7 @@
     "freqCappingLimit": 0,
     "details": {
       "placement_format": "mobile_display",
-      "tag": "<html>\n    <header>\n        <meta name='viewport' content='width=device-width'/>\n        <style>html, body, div { margin: 0px; padding: 0px; } html, body { width: 100%; height: 100%; }</style>\n    </header>\n    <body><script type=\"text/javascript\" src=\"https://eu-west-1-ads.superawesome.tv/v2/ad.js?placement=84799&lineItemId=176805&creativeId=499595&sdkVersion=android_8.3.6_admob&rnd=71922ddc-06aa-4f56-9496-4ae0af720b16&bundle=tv.superawesome.demoapp&dauid=580289352&ct=2&lang=en_US&device=phone&pos=7&timestamp=_TIMESTAMP_&skip=1&playbackmethod=5&startdelay=0&instl=1&isProgrammatic=true\"></script></body>\n    </html>",
+      "tag": "\"<html></html>\"",
       "width": 320,
       "height": 480,
       "duration": 0


### PR DESCRIPTION
This PR adds a new serialiser for the `Ad` object and the logic to set `showPadlock` to `false` if `isKSF` is true as per: https://github.com/SuperAwesomeLTD/sa-mobile-sdk-android/commit/9e55ef4cbe36598491df03b5484f6b25843a005d along with unit tests. 

It seems like `showPadlock` isn't actually used in the refactored code at the moment 🤔 we seem to be using `Config.default` instead?  I can connect it up in this PR but I wanted to raise the PR at this point to get feedback on the changes so far. 