### PR TITLE
chore(): add timestamp to the requests

### DIFF
--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/AdQueryMaker.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/AdQueryMaker.kt
@@ -21,6 +21,7 @@ class AdQueryMaker(
     private val encoder: EncoderType,
     private val json: Json,
     private val locale: Locale,
+    private val timeProvider: TimeProviderType,
 ) : AdQueryMakerType {
 
     override suspend fun makeAdQuery(request: AdRequest): AdQuery = AdQuery(
@@ -39,7 +40,8 @@ class AdQueryMaker(
         startDelay = request.startDelay,
         install = request.install,
         w = request.w,
-        h = request.h
+        h = request.h,
+        timestamp = timeProvider.millis()
     )
 
     override fun makeImpressionQuery(adResponse: AdResponse): EventQuery = EventQuery(

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/TimeProvider.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/TimeProvider.kt
@@ -1,0 +1,12 @@
+package tv.superawesome.sdk.publisher.common.components
+
+interface TimeProviderType {
+    /**
+     * Returns the current time in milliseconds.
+     */
+    fun millis(): Long
+}
+
+class TimeProvider : TimeProviderType {
+    override fun millis(): Long = System.currentTimeMillis()
+}

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/TimeProvider.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/TimeProvider.kt
@@ -1,5 +1,7 @@
 package tv.superawesome.sdk.publisher.common.components
 
+import java.util.*
+
 interface TimeProviderType {
     /**
      * Returns the current time in milliseconds.
@@ -8,5 +10,5 @@ interface TimeProviderType {
 }
 
 class TimeProvider : TimeProviderType {
-    override fun millis(): Long = System.currentTimeMillis()
+    override fun millis(): Long = Calendar.getInstance().timeInMillis
 }

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/di/CommonModule.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/di/CommonModule.kt
@@ -43,8 +43,10 @@ fun createCommonModule(environment: Environment, loggingEnabled: Boolean) = modu
     single<IdGeneratorType> { IdGenerator(get(), get(), get(), get()) }
     single<UserAgentProviderType> { UserAgentProvider(get()) }
     single<ConnectionProviderType> { ConnectionProvider(get()) }
+    single<TimeProviderType> { TimeProvider() }
     single<AdQueryMakerType> {
         AdQueryMaker(
+            get(),
             get(),
             get(),
             get(),

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/AdModels.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/AdModels.kt
@@ -47,6 +47,7 @@ data class AdQuery(
     @SerialName("instl") val install: Int,
     val w: Int,
     val h: Int,
+    val timestamp: Long
 )
 
 data class AdResponse(

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/banner/BannerView.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/banner/BannerView.kt
@@ -13,6 +13,7 @@ import android.widget.ImageView
 import org.koin.java.KoinJavaComponent.inject
 import tv.superawesome.sdk.publisher.common.components.ImageProviderType
 import tv.superawesome.sdk.publisher.common.components.Logger
+import tv.superawesome.sdk.publisher.common.components.TimeProviderType
 import tv.superawesome.sdk.publisher.common.extensions.toPx
 import tv.superawesome.sdk.publisher.common.models.AdRequest
 import tv.superawesome.sdk.publisher.common.models.Constants
@@ -32,6 +33,7 @@ public class BannerView @JvmOverloads constructor(
     private val imageProvider: ImageProviderType by inject(ImageProviderType::class.java)
     private val logger: Logger by inject(Logger::class.java)
     private val moatRepository: MoatRepositoryType by inject(MoatRepositoryType::class.java)
+    private val timeProvider: TimeProviderType by inject(TimeProviderType::class.java)
 
     private var placementId: Int = 0
     private var webView: WebView? = null
@@ -100,11 +102,14 @@ public class BannerView @JvmOverloads constructor(
 
         addWebView()
         showPadlockIfNeeded()
-        val html = moatRepository.startMoatTrackingForDisplay(
+        val moatHtml = moatRepository.startMoatTrackingForDisplay(
             webView as android.webkit.WebView,
             adResponse
         )
-        webView?.loadHTML(data.first, data.second.replace("_MOAT_", html))
+        val bodyHtml = data.second
+            .replace("_MOAT_", moatHtml)
+            .replace("_TIMESTAMP_", timeProvider.millis().toString())
+        webView?.loadHTML(data.first, bodyHtml)
     }
 
     public fun setListener(delegate: SAInterface) {

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/AdQueryMakerTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/AdQueryMakerTest.kt
@@ -15,6 +15,9 @@ import kotlin.test.assertEquals
 
 class AdQueryMakerTest : BaseTest() {
     @MockK
+    lateinit var timeProvider: TimeProviderType
+
+    @MockK
     lateinit var deviceType: DeviceType
 
     @MockK
@@ -53,6 +56,7 @@ class AdQueryMakerTest : BaseTest() {
         every { connectionProviderType.findConnectionType() } returns ConnectionType.Cellular4g
         every { deviceType.genericType } returns DeviceCategory.tablet
         every { locale.toString() } returns "en_en"
+        every { timeProvider.millis() } returns 12345678912345
 
         // When
         val query = runBlocking { queryMaker.makeAdQuery(request) }
@@ -74,6 +78,7 @@ class AdQueryMakerTest : BaseTest() {
         assertEquals(50, query.install)
         assertEquals(60, query.w)
         assertEquals(70, query.h)
+        assertEquals(12345678912345, query.timestamp)
     }
 
     @Test

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/TimeProviderTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/TimeProviderTest.kt
@@ -1,0 +1,27 @@
+package tv.superawesome.sdk.publisher.common.components
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.*
+
+class TimeProviderTest {
+    private val timeProvider = TimeProvider()
+
+    @Test
+    fun test_millis() {
+        // Given
+        val calendar = mockk<Calendar>()
+        mockkStatic(Calendar::class)
+        every { Calendar.getInstance() } returns calendar
+        every { calendar.timeInMillis } returns 12345
+
+        // When
+        val millis = timeProvider.millis()
+
+        // Then
+        assertEquals(millis, 12345)
+    }
+}


### PR DESCRIPTION
Adding the timestamp to the requests in the new codebase. 

Note: Java 8+ `Clock` is not preferred as a source for`TimeProvider` as it is only available API 26 and above. To be able to use it below API 26 we need to enable `coreLibraryDesugaring` which increases the size of our library.

Another alternative is `Calendar.getInstance(). getTimeInMillis()` This could be used but I wanted to avoid creating the `Calendar` object each time. However, if we think this can be better, then I can update the code.