### PR TITLE
chore(): configuration for hiding the safe ad logo for KSF ads

### DIFF
--- a/superawesome-common/build.gradle
+++ b/superawesome-common/build.gradle
@@ -43,8 +43,8 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation('com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.2')
     implementation 'com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0'
-    debugImplementation "com.github.chuckerteam.chucker:library:3.4.0"
-    releaseImplementation "com.github.chuckerteam.chucker:library-no-op:3.4.0"
+    debugImplementation "com.github.chuckerteam.chucker:library:3.5.0"
+    releaseImplementation "com.github.chuckerteam.chucker:library-no-op:3.5.0"
 
     // Unit Testing
     testImplementation "junit:junit:$junit_version"

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/AdModels.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/AdModels.kt
@@ -27,6 +27,7 @@ data class Ad(
     val creative: Creative
 ) {
     fun isCPICampaign(): Boolean = campaignType == CPI_CAMPAIGN_ID
+    fun shouldShowPadlock(): Boolean = showPadlock && !creative.isKSF
 }
 
 @Serializable
@@ -59,7 +60,7 @@ data class AdResponse(
     var referral: String? = null,
 ) {
     fun isVideo(): Boolean = ad.creative.format == CreativeFormatType.Video
-
+    fun shouldShowPadlock(): Boolean = ad.shouldShowPadlock()
     /**
      * Returns `baseUrl` and `html` data to show in the `WebView`
      */

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/Constants.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/Constants.kt
@@ -15,7 +15,6 @@ object Constants {
 
     const val defaultTestMode = false
     const val defaultParentalGate = false
-    const val defaultPadlock = false
     const val defaultBumperPage = false
     const val defaultCloseAtEnd = true
     const val defaultCloseButton = false

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/CreativeModels.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/CreativeModels.kt
@@ -11,7 +11,8 @@ data class Creative(
     @SerialName("click_url") val clickUrl: String? = null,
     val details: CreativeDetail,
     val bumper: Boolean? = null,
-    val referral: CreativeReferral? = null
+    val referral: CreativeReferral? = null,
+    val isKSF: Boolean = false
 )
 
 @Serializable

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/banner/BannerView.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/banner/BannerView.kt
@@ -187,7 +187,7 @@ public class BannerView @JvmOverloads constructor(
     }
 
     private fun showPadlockIfNeeded() {
-        if (!controller.config.shouldShowPadlock || webView == null) return
+        if (!controller.shouldShowPadlock || webView == null) return
 
         val padlockButton = ImageButton(context)
         padlockButton.setImageBitmap(imageProvider.padlockImage())

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/common/AdController.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/common/AdController.kt
@@ -25,9 +25,9 @@ interface AdControllerType {
     var config: Config
     var closed: Boolean
     var moatLimiting: Boolean
-
     var currentAdResponse: AdResponse?
     var delegate: SAInterface?
+    val shouldShowPadlock: Boolean
 
     fun triggerImpressionEvent(placementId: Int)
     fun triggerViewableImpression(placementId: Int)
@@ -58,9 +58,10 @@ class AdController(
     override var config: Config = Config.default
     override var closed: Boolean = false
     override var moatLimiting: Boolean = Constants.defaultMoatLimitingState
-
     override var currentAdResponse: AdResponse? = null
     override var delegate: SAInterface? = null
+    override val shouldShowPadlock: Boolean
+        get() = currentAdResponse?.shouldShowPadlock() ?: false
 
     private val scope = CoroutineScope(Dispatchers.Main)
     private var parentalGate: ParentalGate? = null

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/common/Config.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/common/Config.kt
@@ -9,7 +9,6 @@ import tv.superawesome.sdk.publisher.common.models.Orientation
 open class Config : Parcelable {
     var moatLimiting: Boolean
     var testEnabled: Boolean
-    var shouldShowPadlock: Boolean
     var isParentalGateEnabled: Boolean
     var isBumperPageEnabled: Boolean
     var shouldShowSmallClick: Boolean
@@ -22,7 +21,6 @@ open class Config : Parcelable {
     constructor(
         moatLimiting: Boolean,
         testEnabled: Boolean,
-        shouldShowPadlock: Boolean,
         isParentalGateEnabled: Boolean,
         isBumperPageEnabled: Boolean,
         shouldShowSmallClick: Boolean,
@@ -34,7 +32,6 @@ open class Config : Parcelable {
     ) {
         this.moatLimiting = moatLimiting
         this.testEnabled = testEnabled
-        this.shouldShowPadlock = shouldShowPadlock
         this.isParentalGateEnabled = isParentalGateEnabled
         this.isBumperPageEnabled = isBumperPageEnabled
         this.shouldShowSmallClick = shouldShowSmallClick
@@ -48,7 +45,6 @@ open class Config : Parcelable {
     protected constructor(parcel: Parcel) {
         moatLimiting = parcel.readByte().toInt() != 0
         testEnabled = parcel.readByte().toInt() != 0
-        shouldShowPadlock = parcel.readByte().toInt() != 0
         isParentalGateEnabled = parcel.readByte().toInt() != 0
         isBumperPageEnabled = parcel.readByte().toInt() != 0
         shouldShowSmallClick = parcel.readByte().toInt() != 0
@@ -64,7 +60,6 @@ open class Config : Parcelable {
     override fun writeToParcel(parcel: Parcel, i: Int) {
         parcel.writeByte((if (moatLimiting) 1 else 0).toByte())
         parcel.writeByte((if (testEnabled) 1 else 0).toByte())
-        parcel.writeByte((if (shouldShowPadlock) 1 else 0).toByte())
         parcel.writeByte((if (isParentalGateEnabled) 1 else 0).toByte())
         parcel.writeByte((if (isBumperPageEnabled) 1 else 0).toByte())
         parcel.writeByte((if (shouldShowSmallClick) 1 else 0).toByte())
@@ -83,7 +78,6 @@ open class Config : Parcelable {
         val default = Config(
             moatLimiting = Constants.defaultMoatLimitingState,
             testEnabled = Constants.defaultTestMode,
-            shouldShowPadlock = Constants.defaultPadlock,
             isParentalGateEnabled = Constants.defaultParentalGate,
             isBumperPageEnabled = Constants.defaultBumperPage,
             shouldShowSmallClick = Constants.defaultSmallClick,

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/managed/ManagedBannerView.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/managed/ManagedBannerView.kt
@@ -155,7 +155,7 @@ public class ManagedBannerView @JvmOverloads constructor(
     }
 
     private fun showPadlockIfNeeded() {
-        if (!controller.config.shouldShowPadlock || webView == null) return
+        if (!controller.shouldShowPadlock || webView == null) return
 
         val padlockButton = ImageButton(context)
         padlockButton.setImageBitmap(imageProvider.padlockImage())

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/video/VideoActivity.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/video/VideoActivity.kt
@@ -55,21 +55,10 @@ class VideoActivity : FullScreenActivity() {
         val size = RelativeLayout.LayoutParams.MATCH_PARENT
         val params = RelativeLayout.LayoutParams(size, size)
 
-        // Chrome
-        val chrome = AdVideoPlayerControllerView(this)
-        chrome.shouldShowPadlock(config.shouldShowPadlock)
-        chrome.setShouldShowSmallClickButton(config.shouldShowSmallClick)
-        chrome.setClickListener {
-            controller.adClicked()
-            controller.handleAdTapForVast(this)
-        }
-        chrome.padlock.setOnClickListener { controller.handleSafeAdTap(this) }
-
         // Video Player
         videoPlayer = VideoPlayer(this)
         videoPlayer.layoutParams = params
         videoPlayer.setController(control)
-        videoPlayer.setControllerView(chrome)
         videoPlayer.setBackgroundColor(Color.BLACK)
         parentLayout.addView(videoPlayer)
 
@@ -95,10 +84,10 @@ class VideoActivity : FullScreenActivity() {
             }
 
             override fun onError(
-                player: IVideoPlayer,
-                error: Throwable,
-                time: Int,
-                duration: Int
+               player: IVideoPlayer,
+               error: Throwable,
+               time: Int,
+               duration: Int
             ) {
                 videoEvents?.error(player, time, duration)
                 controller.adFailedToShow()
@@ -109,10 +98,11 @@ class VideoActivity : FullScreenActivity() {
 
     public override fun playContent() {
         controller.play(placementId)?.let {
+            addChrome()
             it.vast?.let { _ ->
                 videoEvents = get(
-                    clazz = VideoEvents::class.java,
-                    parameters = { parametersOf(it, config.moatLimiting) }
+                   clazz = VideoEvents::class.java,
+                   parameters = { parametersOf(it, config.moatLimiting) }
                 )
                 val filePath = it.filePath ?: ""
                 try {
@@ -141,6 +131,18 @@ class VideoActivity : FullScreenActivity() {
         val height = displayMetrics.heightPixels
         val width = displayMetrics.widthPixels
         videoPlayer.updateLayout(width, height)
+    }
+
+    private fun addChrome() {
+        val chrome = AdVideoPlayerControllerView(this)
+        chrome.shouldShowPadlock(controller.shouldShowPadlock)
+        chrome.setShouldShowSmallClickButton(config.shouldShowSmallClick)
+        chrome.setClickListener {
+            controller.adClicked()
+            controller.handleAdTapForVast(this)
+        }
+        chrome.padlock.setOnClickListener { controller.handleSafeAdTap(this) }
+        videoPlayer.setControllerView(chrome)
     }
 
     companion object {

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/video/VideoComponentFactory.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/video/VideoComponentFactory.kt
@@ -11,6 +11,7 @@ import android.widget.RelativeLayout
 import android.widget.TextView
 import org.koin.java.KoinJavaComponent.inject
 import tv.superawesome.sdk.publisher.common.components.ImageProviderType
+import tv.superawesome.sdk.publisher.common.extensions.toPx
 
 class VideoComponentFactory {
     private val imageProvider: ImageProviderType by inject(ImageProviderType::class.java)
@@ -103,7 +104,7 @@ class VideoComponentFactory {
         val view = ImageButton(context)
         view.id = id
         view.setImageBitmap(imageProvider.padlockImage())
-        view.setPadding(0, 0, 0, 0)
+        view.setPadding(0, 2.toPx, 0, 0)
         view.setBackgroundColor(Color.TRANSPARENT)
         view.scaleType = ImageView.ScaleType.FIT_XY
         view.layoutParams = ViewGroup.LayoutParams((77 * scale).toInt(), (31 * scale).toInt())

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/AdResponseTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/AdResponseTest.kt
@@ -1,0 +1,78 @@
+package tv.superawesome.sdk.publisher.common.components
+
+import org.junit.Test
+import tv.superawesome.sdk.publisher.common.models.*
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class AdResponseTest {
+
+    @Test
+    fun test_standard_shouldShowPadlock_true() {
+
+        var ad = buildAd(showPadlock = true, isKSF = false)
+
+        val response = AdResponse(10, ad)
+
+        assertTrue { response.shouldShowPadlock() }
+    }
+
+    @Test
+    fun test_standard_shouldShowPadlock_false() {
+
+        var ad = buildAd(showPadlock = false, isKSF = false)
+
+        val response = AdResponse(10, ad)
+
+        assertFalse { response.shouldShowPadlock() }
+    }
+
+    @Test
+    fun test_ksf_shouldShowPadlock_showPadlock_true() {
+
+        var ad = buildAd(showPadlock = true, isKSF = true)
+
+        val response = AdResponse(10, ad)
+
+        assertFalse { response.shouldShowPadlock() }
+    }
+
+    @Test
+    fun test_ksf_shouldShowPadlock_showPadlock_false() {
+
+        var ad = buildAd(showPadlock = false, isKSF = true)
+
+        val response = AdResponse(10, ad)
+
+        assertFalse { response.shouldShowPadlock() }
+    }
+
+    private fun buildAd(showPadlock: Boolean, isKSF: Boolean = false) = Ad(
+        advertiserId = null,
+        publisherId = 123,
+        moat = 10.0f,
+        isFill = false,
+        isFallback = false,
+        campaignType = 123,
+        campaignId = 123,
+        isHouse = false,
+        safeAdApproved = false,
+        showPadlock = showPadlock,
+        lineItemId = 123,
+        test = false,
+        app = 123,
+        device = "android",
+        creative = Creative(
+            id = 10,
+            format = CreativeFormatType.Video,
+            referral = CreativeReferral(),
+            details = CreativeDetail(
+                placementFormat = "",
+                width = 1,
+                height = 1,
+                duration = 1
+            ),
+            isKSF = isKSF
+        )
+    )
+}


### PR DESCRIPTION
This PR hides the safe ad logo for KSF Ads and fixes a crashing issue with the chucker library for API 31 and above in the common `build.gradle`.

I had to make some changes to `VideoActivity` since the `currentAdResponse` is not retrieved from the `AdStore` until `play`. The changes are similar to how the `WebView` is added in `BannerView` without the removal since the `VideoActivity` replaces the `IVideoPlayerControllerView` itself and it's destroyed on close. I've also matched the safe ad logo padding to the `BannerView` padding but we may want to tweak the padding / positioning for both for styling reasons.