### PR TITLE
Fix/aag 2263 get version from properties

### DIFF
--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
@@ -17,7 +17,12 @@ class SdkInfo(
     private val encoder: EncoderType,
     locale: Locale
 ) : SdkInfoType {
-    private object VersionInfo {
+    private object Keys {
+        const val Unknown = "unknown"
+        const val Platform = "android"
+        const val VersionFile = "version.properties"
+        const val VersionName = "version.name"
+
         val storedVersion = loadVersion()
 
         /**
@@ -34,8 +39,8 @@ class SdkInfo(
     }
 
     override val version: String
-        get() = overrideVersion ?: "${Platform}_${VersionInfo.storedVersion}"
-    override val bundle: String = context.packageName ?: Unknown
+        get() = overrideVersion ?: "${Keys.Platform}_${Keys.storedVersion}"
+    override val bundle: String = context.packageName ?: Keys.Unknown
     override val name: String by lazy { findAppName() }
     override val lang: String = locale.toString()
 
@@ -43,7 +48,7 @@ class SdkInfo(
         val label = context.packageManager.getApplicationLabel(context.applicationInfo).toString()
         encoder.encodeUri(label)
     } catch (exception: PackageManager.NameNotFoundException) {
-        Unknown
+        Keys.Unknown
     }
 
     companion object {
@@ -51,8 +56,3 @@ class SdkInfo(
         var overridePlatform: String? = null
     }
 }
-
-const val Unknown = "unknown"
-const val Platform = "android"
-const val VersionFile = "version.properties"
-const val VersionName = "version.name"

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
@@ -18,8 +18,11 @@ class SdkInfo(
     locale: Locale
 ) : SdkInfoType {
     private object Keys {
-        const val unknown = "unknown"
-        const val platform = "android"
+        const val Unknown = "unknown"
+        const val Platform = "android"
+        const val VersionFile = "version.properties"
+        const val VersionName = "version.name"
+
         val storedVersion = loadVersion()
 
         /**
@@ -27,22 +30,17 @@ class SdkInfo(
          *
          * @return the stored string representing the current version
          */
-
         fun loadVersion(): String {
+            val inputStream = javaClass.classLoader?.getResourceAsStream(VersionFile) ?: return ""
             val properties = Properties()
-            val inputStream = javaClass.classLoader?.getResourceAsStream("version.properties")
-            return if(inputStream != null) {
-                properties.load(inputStream)
-                properties?.getProperty("version.name") ?: ""
-            } else {
-                ""
-            }
+            properties.load(inputStream)
+            return properties.getProperty(VersionName) ?: ""
         }
     }
 
     override val version: String
-        get() = overrideVersion ?: "${Keys.platform}_${Keys.storedVersion}"
-    override val bundle: String = context.packageName ?: Keys.unknown
+        get() = overrideVersion ?: "${Keys.Platform}_${Keys.storedVersion}"
+    override val bundle: String = context.packageName ?: Keys.Unknown
     override val name: String by lazy { findAppName() }
     override val lang: String = locale.toString()
 
@@ -50,7 +48,7 @@ class SdkInfo(
         val label = context.packageManager.getApplicationLabel(context.applicationInfo).toString()
         encoder.encodeUri(label)
     } catch (exception: PackageManager.NameNotFoundException) {
-        Keys.unknown
+        Keys.Unknown
     }
 
     companion object {

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
@@ -15,8 +15,7 @@ interface SdkInfoType {
 class SdkInfo(
     private val context: Context,
     private val encoder: EncoderType,
-    locale: Locale,
-    private val versionFileName: String = "version.properties"
+    locale: Locale
 ) : SdkInfoType {
     object Keys {
         const val unknown = "unknown"
@@ -36,9 +35,15 @@ class SdkInfo(
         Keys.unknown
     }
 
+    /**
+     * Method to load the current version from version.properties.
+     *
+     * @return the stored string representing the current version
+     */
+
     private fun loadVersion(): String {
         val properties = Properties()
-        val inputStream = javaClass.classLoader?.getResourceAsStream(versionFileName)
+        val inputStream = javaClass.classLoader?.getResourceAsStream("version.properties")
         return if(inputStream != null) {
             properties.load(inputStream)
             properties?.getProperty("version.name") ?: ""

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
@@ -17,13 +17,31 @@ class SdkInfo(
     private val encoder: EncoderType,
     locale: Locale
 ) : SdkInfoType {
-    object Keys {
+    private object Keys {
         const val unknown = "unknown"
         const val platform = "android"
+        val storedVersion = loadVersion()
+
+        /**
+         * Method to load the current version from version.properties.
+         *
+         * @return the stored string representing the current version
+         */
+
+        fun loadVersion(): String {
+            val properties = Properties()
+            val inputStream = javaClass.classLoader?.getResourceAsStream("version.properties")
+            return if(inputStream != null) {
+                properties.load(inputStream)
+                properties?.getProperty("version.name") ?: ""
+            } else {
+                ""
+            }
+        }
     }
 
     override val version: String
-        get() = overrideVersion ?: "${Keys.platform}_${loadVersion()}"
+        get() = overrideVersion ?: "${Keys.platform}_${Keys.storedVersion}"
     override val bundle: String = context.packageName ?: Keys.unknown
     override val name: String by lazy { findAppName() }
     override val lang: String = locale.toString()
@@ -33,23 +51,6 @@ class SdkInfo(
         encoder.encodeUri(label)
     } catch (exception: PackageManager.NameNotFoundException) {
         Keys.unknown
-    }
-
-    /**
-     * Method to load the current version from version.properties.
-     *
-     * @return the stored string representing the current version
-     */
-
-    private fun loadVersion(): String {
-        val properties = Properties()
-        val inputStream = javaClass.classLoader?.getResourceAsStream("version.properties")
-        return if(inputStream != null) {
-            properties.load(inputStream)
-            properties?.getProperty("version.name") ?: ""
-        } else {
-            ""
-        }
     }
 
     companion object {

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
@@ -17,12 +17,7 @@ class SdkInfo(
     private val encoder: EncoderType,
     locale: Locale
 ) : SdkInfoType {
-    private object Keys {
-        const val Unknown = "unknown"
-        const val Platform = "android"
-        const val VersionFile = "version.properties"
-        const val VersionName = "version.name"
-
+    private object VersionInfo {
         val storedVersion = loadVersion()
 
         /**
@@ -39,8 +34,8 @@ class SdkInfo(
     }
 
     override val version: String
-        get() = overrideVersion ?: "${Keys.Platform}_${Keys.storedVersion}"
-    override val bundle: String = context.packageName ?: Keys.Unknown
+        get() = overrideVersion ?: "${Platform}_${VersionInfo.storedVersion}"
+    override val bundle: String = context.packageName ?: Unknown
     override val name: String by lazy { findAppName() }
     override val lang: String = locale.toString()
 
@@ -48,7 +43,7 @@ class SdkInfo(
         val label = context.packageManager.getApplicationLabel(context.applicationInfo).toString()
         encoder.encodeUri(label)
     } catch (exception: PackageManager.NameNotFoundException) {
-        Keys.Unknown
+        Unknown
     }
 
     companion object {
@@ -56,3 +51,8 @@ class SdkInfo(
         var overridePlatform: String? = null
     }
 }
+
+const val Unknown = "unknown"
+const val Platform = "android"
+const val VersionFile = "version.properties"
+const val VersionName = "version.name"

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
@@ -3,6 +3,7 @@ package tv.superawesome.sdk.publisher.common.components
 import android.content.Context
 import android.content.pm.PackageManager
 import java.util.Locale
+import java.util.Properties
 
 interface SdkInfoType {
     val version: String
@@ -15,7 +16,7 @@ class SdkInfo(
     private val context: Context,
     private val encoder: EncoderType,
     locale: Locale,
-    private val versionNumber: String
+    private val versionFileName: String = "version.properties"
 ) : SdkInfoType {
     object Keys {
         const val unknown = "unknown"
@@ -23,7 +24,7 @@ class SdkInfo(
     }
 
     override val version: String
-        get() = overrideVersion ?: "${Keys.platform}_$versionNumber"
+        get() = overrideVersion ?: "${Keys.platform}_${loadVersion()}"
     override val bundle: String = context.packageName ?: Keys.unknown
     override val name: String by lazy { findAppName() }
     override val lang: String = locale.toString()
@@ -33,6 +34,17 @@ class SdkInfo(
         encoder.encodeUri(label)
     } catch (exception: PackageManager.NameNotFoundException) {
         Keys.unknown
+    }
+
+    private fun loadVersion(): String {
+        val properties = Properties()
+        val inputStream = javaClass.classLoader?.getResourceAsStream(versionFileName)
+        return if(inputStream != null) {
+            properties.load(inputStream)
+            properties?.getProperty("version.name") ?: ""
+        } else {
+            ""
+        }
     }
 
     companion object {

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/di/CommonModule.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/di/CommonModule.kt
@@ -36,7 +36,7 @@ fun createCommonModule(environment: Environment, loggingEnabled: Boolean) = modu
     single { Locale.getDefault() }
     single { Resources.getSystem().displayMetrics }
     factory<GoogleAdvertisingProxyType> { GoogleAdvertisingProxy(get()) }
-    single<SdkInfoType> { SdkInfo(get(), get(), get(), "1.2.3") }
+    single<SdkInfoType> { SdkInfo(get(), get(), get()) }
     single<NumberGeneratorType> { NumberGenerator() }
     single<DeviceType> { Device(get()) }
     single<EncoderType> { Encoder() }

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/SdkInfoTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/SdkInfoTest.kt
@@ -14,10 +14,12 @@ class SdkInfoTest : BaseTest() {
     @Test
     fun testSdkInfo() {
         // Given
+        val versionFileName = "mock_version.properties"
         val locale = Locale("xx", "YY")
         val mockPackageManager = mockk<PackageManager> {
             every { getApplicationLabel(any()) } returns "testAppName"
         }
+
         val mockApplicationInfo = mockk<ApplicationInfo>()
         val context = mockk<Context> {
             every { packageName } returns "testBundleName"
@@ -26,12 +28,28 @@ class SdkInfoTest : BaseTest() {
         }
         val encoderType = Encoder()
 
-        val sdkInfo = SdkInfo(context, encoderType, locale, "1.2.3")
+        val sdkInfo = SdkInfo(context, encoderType, locale, versionFileName)
 
         // Then
         assertEquals("testBundleName", sdkInfo.bundle)
         assertEquals("testAppName", sdkInfo.name)
         assertEquals("xx_YY", sdkInfo.lang)
         assertEquals("android_1.2.3", sdkInfo.version)
+    }
+
+    @Test
+    fun testSdkInfo_version_incorrect_properties_path() {
+        // Given
+        val versionFileName = ""
+        val locale = Locale("xx", "YY")
+        val context = mockk<Context> {
+            every { packageName } returns "testBundleName"
+        }
+        val encoderType = Encoder()
+
+        val sdkInfo = SdkInfo(context, encoderType, locale, versionFileName)
+
+        // Then
+        assertEquals("android_", sdkInfo.version)
     }
 }

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/SdkInfoTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/SdkInfoTest.kt
@@ -14,7 +14,6 @@ class SdkInfoTest : BaseTest() {
     @Test
     fun testSdkInfo() {
         // Given
-        val versionFileName = "mock_version.properties"
         val locale = Locale("xx", "YY")
         val mockPackageManager = mockk<PackageManager> {
             every { getApplicationLabel(any()) } returns "testAppName"
@@ -28,28 +27,12 @@ class SdkInfoTest : BaseTest() {
         }
         val encoderType = Encoder()
 
-        val sdkInfo = SdkInfo(context, encoderType, locale, versionFileName)
+        val sdkInfo = SdkInfo(context, encoderType, locale)
 
         // Then
         assertEquals("testBundleName", sdkInfo.bundle)
         assertEquals("testAppName", sdkInfo.name)
         assertEquals("xx_YY", sdkInfo.lang)
         assertEquals("android_1.2.3", sdkInfo.version)
-    }
-
-    @Test
-    fun testSdkInfo_version_incorrect_properties_path() {
-        // Given
-        val versionFileName = ""
-        val locale = Locale("xx", "YY")
-        val context = mockk<Context> {
-            every { packageName } returns "testBundleName"
-        }
-        val encoderType = Encoder()
-
-        val sdkInfo = SdkInfo(context, encoderType, locale, versionFileName)
-
-        // Then
-        assertEquals("android_", sdkInfo.version)
     }
 }

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/SdkInfoTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/SdkInfoTest.kt
@@ -18,7 +18,6 @@ class SdkInfoTest : BaseTest() {
         val mockPackageManager = mockk<PackageManager> {
             every { getApplicationLabel(any()) } returns "testAppName"
         }
-
         val mockApplicationInfo = mockk<ApplicationInfo>()
         val context = mockk<Context> {
             every { packageName } returns "testBundleName"

--- a/superawesome-common/src/test/resources/mock_version.properties
+++ b/superawesome-common/src/test/resources/mock_version.properties
@@ -1,0 +1,1 @@
+version.name=1.2.3

--- a/superawesome-common/src/test/resources/mock_version.properties
+++ b/superawesome-common/src/test/resources/mock_version.properties
@@ -1,1 +1,0 @@
-version.name=1.2.3

--- a/superawesome-common/src/test/resources/version.properties
+++ b/superawesome-common/src/test/resources/version.properties
@@ -1,0 +1,1 @@
+version.name=1.2.3


### PR DESCRIPTION
This PR adds support for loading the `version.properties` file to `SdkInfo`. Whilst adding this I noticed that the `overridePlatform` String isn't used, do we need to make sure this class can output the same SDK version string as `SAVersion.getSDKVersion()` ?