### PR TITLE
chore(): Added additional query options set at SDK init

### DIFF
--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/extensions/PropertiesExtensions.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/extensions/PropertiesExtensions.kt
@@ -1,0 +1,13 @@
+package tv.superawesome.sdk.publisher.common.extensions
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.properties.Properties
+import kotlinx.serialization.properties.encodeToMap
+
+@ExperimentalSerializationApi
+inline fun <reified T> Properties.encodeToMap(value: T,
+                                              additionalMap: Map<String, Any>?): Map<String, Any> {
+    val map = encodeToMap(value)
+    val additionalMap = additionalMap ?: return map
+    return map + additionalMap
+}

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/extensions/PropertiesExtensions.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/extensions/PropertiesExtensions.kt
@@ -4,9 +4,15 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.properties.Properties
 import kotlinx.serialization.properties.encodeToMap
 
+/**
+ * Encodes a type to a map and optionally appends another map.
+ * @param value - the type to encode
+ * @param additionalMap - an optional map to merge with the encoded type
+ * @return the encoded map merged with an additional map if one is passed.
+ */
 @ExperimentalSerializationApi
-inline fun <reified T> Properties.encodeToMap(value: T,
-                                              additionalMap: Map<String, Any>?): Map<String, Any> {
+inline fun <reified T> Properties.mergeToMap(value: T,
+                                             additionalMap: Map<String, Any>?): Map<String, Any> {
     val map = encodeToMap(value)
     val additionalMap = additionalMap ?: return map
     return map + additionalMap

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/QueryAdditionalOptions.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/models/QueryAdditionalOptions.kt
@@ -1,0 +1,7 @@
+package tv.superawesome.sdk.publisher.common.models
+
+data class QueryAdditionalOptions(val options: Map<String, String>) {
+    companion object {
+        var instance: QueryAdditionalOptions? = null
+    }
+}

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/network/retrofit/RetrofitAdDataSource.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/network/retrofit/RetrofitAdDataSource.kt
@@ -2,11 +2,12 @@ package tv.superawesome.sdk.publisher.common.network.retrofit
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.properties.Properties
-import kotlinx.serialization.properties.encodeToMap
 import tv.superawesome.sdk.publisher.common.datasources.AwesomeAdsApiDataSourceType
+import tv.superawesome.sdk.publisher.common.extensions.encodeToMap
 import tv.superawesome.sdk.publisher.common.models.Ad
 import tv.superawesome.sdk.publisher.common.models.AdQuery
 import tv.superawesome.sdk.publisher.common.models.EventQuery
+import tv.superawesome.sdk.publisher.common.models.QueryAdditionalOptions
 import tv.superawesome.sdk.publisher.common.network.DataResult
 
 @ExperimentalSerializationApi
@@ -14,7 +15,12 @@ class RetrofitAdDataSource(private val awesomeAdsApi: RetrofitAwesomeAdsApi) :
     AwesomeAdsApiDataSourceType {
 
     override suspend fun getAd(placementId: Int, query: AdQuery): DataResult<Ad> = try {
-        DataResult.Success(awesomeAdsApi.ad(placementId, Properties.encodeToMap(query)))
+        DataResult.Success(
+            awesomeAdsApi.ad(
+                placementId,
+                Properties.encodeToMap(query, QueryAdditionalOptions.instance?.options)
+            )
+        )
     } catch (exception: Exception) {
         DataResult.Failure(exception)
     }
@@ -26,7 +32,7 @@ class RetrofitAdDataSource(private val awesomeAdsApi: RetrofitAwesomeAdsApi) :
                     placementId,
                     lineItemId,
                     creativeId,
-                    Properties.encodeToMap(query)
+                    Properties.encodeToMap(query, QueryAdditionalOptions.instance?.options)
                 )
             )
         } catch (exception: Exception) {
@@ -34,25 +40,41 @@ class RetrofitAdDataSource(private val awesomeAdsApi: RetrofitAwesomeAdsApi) :
         }
 
     override suspend fun impression(query: EventQuery): DataResult<Void> = try {
-        DataResult.Success(awesomeAdsApi.impression(Properties.encodeToMap(query)))
+        DataResult.Success(
+            awesomeAdsApi.impression(
+                Properties.encodeToMap(query, QueryAdditionalOptions.instance?.options)
+            )
+        )
     } catch (exception: Exception) {
         DataResult.Failure(exception)
     }
 
     override suspend fun click(query: EventQuery): DataResult<Void> = try {
-        DataResult.Success(awesomeAdsApi.click(Properties.encodeToMap(query)))
+        DataResult.Success(
+            awesomeAdsApi.click(
+                Properties.encodeToMap(query, QueryAdditionalOptions.instance?.options)
+            )
+        )
     } catch (exception: Exception) {
         DataResult.Failure(exception)
     }
 
     override suspend fun videoClick(query: EventQuery): DataResult<Void> = try {
-        DataResult.Success(awesomeAdsApi.videoClick(Properties.encodeToMap(query)))
+        DataResult.Success(
+            awesomeAdsApi.videoClick(
+                Properties.encodeToMap(query, QueryAdditionalOptions.instance?.options)
+            )
+        )
     } catch (exception: Exception) {
         DataResult.Failure(exception)
     }
 
     override suspend fun event(query: EventQuery): DataResult<Void> = try {
-        DataResult.Success(awesomeAdsApi.event(Properties.encodeToMap(query)))
+        DataResult.Success(
+            awesomeAdsApi.event(
+                Properties.encodeToMap(query, QueryAdditionalOptions.instance?.options)
+            )
+        )
     } catch (exception: Exception) {
         DataResult.Failure(exception)
     }

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/network/retrofit/RetrofitAdDataSource.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/network/retrofit/RetrofitAdDataSource.kt
@@ -3,7 +3,7 @@ package tv.superawesome.sdk.publisher.common.network.retrofit
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.properties.Properties
 import tv.superawesome.sdk.publisher.common.datasources.AwesomeAdsApiDataSourceType
-import tv.superawesome.sdk.publisher.common.extensions.encodeToMap
+import tv.superawesome.sdk.publisher.common.extensions.mergeToMap
 import tv.superawesome.sdk.publisher.common.models.Ad
 import tv.superawesome.sdk.publisher.common.models.AdQuery
 import tv.superawesome.sdk.publisher.common.models.EventQuery
@@ -18,7 +18,7 @@ class RetrofitAdDataSource(private val awesomeAdsApi: RetrofitAwesomeAdsApi) :
         DataResult.Success(
             awesomeAdsApi.ad(
                 placementId,
-                Properties.encodeToMap(query, QueryAdditionalOptions.instance?.options)
+                Properties.mergeToMap(query, QueryAdditionalOptions.instance?.options)
             )
         )
     } catch (exception: Exception) {
@@ -32,7 +32,7 @@ class RetrofitAdDataSource(private val awesomeAdsApi: RetrofitAwesomeAdsApi) :
                     placementId,
                     lineItemId,
                     creativeId,
-                    Properties.encodeToMap(query, QueryAdditionalOptions.instance?.options)
+                    Properties.mergeToMap(query, QueryAdditionalOptions.instance?.options)
                 )
             )
         } catch (exception: Exception) {
@@ -42,7 +42,7 @@ class RetrofitAdDataSource(private val awesomeAdsApi: RetrofitAwesomeAdsApi) :
     override suspend fun impression(query: EventQuery): DataResult<Void> = try {
         DataResult.Success(
             awesomeAdsApi.impression(
-                Properties.encodeToMap(query, QueryAdditionalOptions.instance?.options)
+                Properties.mergeToMap(query, QueryAdditionalOptions.instance?.options)
             )
         )
     } catch (exception: Exception) {
@@ -52,7 +52,7 @@ class RetrofitAdDataSource(private val awesomeAdsApi: RetrofitAwesomeAdsApi) :
     override suspend fun click(query: EventQuery): DataResult<Void> = try {
         DataResult.Success(
             awesomeAdsApi.click(
-                Properties.encodeToMap(query, QueryAdditionalOptions.instance?.options)
+                Properties.mergeToMap(query, QueryAdditionalOptions.instance?.options)
             )
         )
     } catch (exception: Exception) {
@@ -62,7 +62,7 @@ class RetrofitAdDataSource(private val awesomeAdsApi: RetrofitAwesomeAdsApi) :
     override suspend fun videoClick(query: EventQuery): DataResult<Void> = try {
         DataResult.Success(
             awesomeAdsApi.videoClick(
-                Properties.encodeToMap(query, QueryAdditionalOptions.instance?.options)
+                Properties.mergeToMap(query, QueryAdditionalOptions.instance?.options)
             )
         )
     } catch (exception: Exception) {
@@ -72,7 +72,7 @@ class RetrofitAdDataSource(private val awesomeAdsApi: RetrofitAwesomeAdsApi) :
     override suspend fun event(query: EventQuery): DataResult<Void> = try {
         DataResult.Success(
             awesomeAdsApi.event(
-                Properties.encodeToMap(query, QueryAdditionalOptions.instance?.options)
+                Properties.mergeToMap(query, QueryAdditionalOptions.instance?.options)
             )
         )
     } catch (exception: Exception) {

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/sdk/AwesomeAdsSdk.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/sdk/AwesomeAdsSdk.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.KoinApplication
 import org.koin.core.context.startKoin
+import tv.superawesome.sdk.publisher.common.models.QueryAdditionalOptions
 import tv.superawesome.sdk.publisher.common.di.createCommonModule
 import tv.superawesome.sdk.publisher.common.models.Configuration
 
@@ -13,6 +14,14 @@ object AwesomeAdsSdk {
     @JvmStatic
     fun init(applicationContext: Context, configuration: Configuration) {
         if (app == null) {
+            app = buildKoinApplication(applicationContext, configuration)
+        }
+    }
+
+    @JvmStatic
+    fun init(applicationContext: Context, configuration: Configuration, options: Map<String, String>) {
+        if (app == null) {
+            QueryAdditionalOptions.instance = QueryAdditionalOptions(options)
             app = buildKoinApplication(applicationContext, configuration)
         }
     }

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/AdQueryMakerTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/AdQueryMakerTest.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.properties.Properties
 import org.junit.Test
 import tv.superawesome.sdk.publisher.common.base.BaseTest
-import tv.superawesome.sdk.publisher.common.extensions.encodeToMap
+import tv.superawesome.sdk.publisher.common.extensions.mergeToMap
 import tv.superawesome.sdk.publisher.common.models.*
 import java.util.*
 import kotlin.test.assertEquals
@@ -191,7 +191,7 @@ class AdQueryMakerTest : BaseTest() {
         val query = runBlocking { queryMaker.makeAdQuery(request) }
         val options = mapOf("key1" to "value1", "key2" to "value2")
         QueryAdditionalOptions.instance = QueryAdditionalOptions(options)
-        val encoded = Properties.encodeToMap(query, QueryAdditionalOptions.instance?.options)
+        val encoded = Properties.mergeToMap(query, QueryAdditionalOptions.instance?.options)
 
         // Then
         assertTrue(encoded.entries.containsAll(options.entries))
@@ -215,7 +215,7 @@ class AdQueryMakerTest : BaseTest() {
 
         // When
         val query = runBlocking { queryMaker.makeAdQuery(request) }
-        val encoded = Properties.encodeToMap(query, null)
+        val encoded = Properties.mergeToMap(query, null)
 
         // Then
         assertEquals("" +


### PR DESCRIPTION
This PR adds a new initialiser for the refactored SDK that allows a map of additional options to be passed that are added to each request query.

Here is an example url outputted when using the initialiser with an options map (`testKey` and `testValue` are set from the options map):

`https://ads.superawesome.tv/v2/ad/88406?test=false&sdkVersion=android_8.3.6&rnd=1389563&bundle=tv.superawesome.demoapp&name=SASDK%2B-%2BAndroid&dauid=611023259&ct=Wifi&lang=en_US&device=phone&pos=7&skip=1&playbackmethod=5&startdelay=0&instl=1&w=1080&h=2160&timestamp=1661940061004&testKey=testValue`