### PR TITLE
Chore/aag 2388 investigate ad ended and ad closed duplicate events

### DIFF
--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/videoPlayer/VideoPlayerController.kt
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/videoPlayer/VideoPlayerController.kt
@@ -104,14 +104,12 @@ class VideoPlayerController :
     }
 
     override fun onCompletion(mediaPlayer: MediaPlayer) {
-        //removeTimer()
         reset()
         listener?.onMediaComplete(this, currentPosition, duration)
     }
 
     // todo: why doesn't the video player stop at the error?
     override fun onError(mediaPlayer: MediaPlayer, error: Int, payload: Int): Boolean {
-        //removeTimer()
         reset()
         listener?.onError(this, Throwable(), 0, 0)
         return false

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/videoPlayer/VideoPlayerController.kt
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/videoPlayer/VideoPlayerController.kt
@@ -61,8 +61,8 @@ class VideoPlayerController :
     }
 
     override fun reset() {
+        removeTimer()
         try {
-            removeTimer()
             super.reset()
         } catch (ignored: Exception) {
         }
@@ -104,14 +104,14 @@ class VideoPlayerController :
     }
 
     override fun onCompletion(mediaPlayer: MediaPlayer) {
-        removeTimer()
-        // todo: add a "reset" here and see how it goes
+        //removeTimer()
+        reset()
         listener?.onMediaComplete(this, currentPosition, duration)
     }
 
     // todo: why doesn't the video player stop at the error?
     override fun onError(mediaPlayer: MediaPlayer, error: Int, payload: Int): Boolean {
-        removeTimer()
+        //removeTimer()
         reset()
         listener?.onError(this, Throwable(), 0, 0)
         return false


### PR DESCRIPTION
This PR adds a fix for multiple `adEnded` and `adClosed` events being sent. It was already hinted at in the comments in the code - resetting on complete fixes it. There was also a call to `removeTimer()` within reset so there doesn't seem to be a need to call it twice. Since it's safe to call I've moved it out of the `try` in `reset()`.

Before:

<img width="851" alt="Screenshot 2022-08-31 at 12 32 44" src="https://user-images.githubusercontent.com/30452349/187669658-bca43aae-f362-4f3c-a4dc-1f585b4b8c08.png">

After:

<img width="861" alt="Screenshot 2022-08-31 at 12 42 03" src="https://user-images.githubusercontent.com/30452349/187670646-2ea53be4-ecb7-4adb-aaa5-9f51c53ba89b.png">