### PR TITLE
chore(): Prevent duplicate adClosed and adEnded events

### DIFF
--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoActivity.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoActivity.java
@@ -28,7 +28,6 @@ import tv.superawesome.lib.samodelspace.saad.SAAd;
 import tv.superawesome.lib.saparentalgate.SAParentalGate;
 import tv.superawesome.lib.sautils.SAImageUtils;
 import tv.superawesome.lib.sautils.SAUtils;
-import tv.superawesome.sdk.publisher.base.R;
 import tv.superawesome.sdk.publisher.state.CloseButtonState;
 import tv.superawesome.sdk.publisher.video.AdVideoPlayerControllerView;
 import tv.superawesome.sdk.publisher.video.VideoUtils;
@@ -215,6 +214,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
         if (config.shouldCloseAtEnd) {
             close();
         }
+        removeListenerRef();
     }
 
     @Override
@@ -275,6 +275,11 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
         // close
         this.finish();
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        removeListenerRef();
+    }
+
+    private void removeListenerRef() {
+        listenerRef = null;
     }
 
     @Override


### PR DESCRIPTION
This PR removes the `listenerRef` in the `SAVideoActivity` when the video is either completed or closed to prevent duplicate events being sent. Please see the attached video for the manual testing:

https://user-images.githubusercontent.com/30452349/188128681-4723cb1b-6990-4614-be25-c4edad7e5fcb.mov
