### PR TITLE
chore(): Expose version number

### DIFF
--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVersion.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVersion.java
@@ -37,7 +37,7 @@ public class SAVersion {
     /**
      * Getter for the current SDK
      *
-     * @return string representing the current SDK
+     * @return a string representing the current SDK
      */
     private static String getSdk() {
         return sdk;
@@ -46,7 +46,7 @@ public class SAVersion {
     /**
      * Getter for the current version
      *
-     * @return string representing the current version
+     * @return a string representing the current version
      */
     public static String getSDKVersionNumber() {
         return versionOverride == null ? version : versionOverride;

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVersion.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVersion.java
@@ -46,7 +46,7 @@ public class SAVersion {
     /**
      * Getter for the current version number
      *
-     * @return a string representing the current version
+     * @return a string representing the current version number
      */
     public static String getSDKVersionNumber() {
         return versionOverride == null ? version : versionOverride;

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVersion.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVersion.java
@@ -44,7 +44,7 @@ public class SAVersion {
     }
 
     /**
-     * Getter for the current version
+     * Getter for the current version number
      *
      * @return a string representing the current version
      */

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVersion.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVersion.java
@@ -18,15 +18,6 @@ public class SAVersion {
     }
 
     /**
-     * Getter for the current version
-     *
-     * @return string representing the current version
-     */
-    private static String getVersion() {
-        return versionOverride == null ? version : versionOverride;
-    }
-
-    /**
      * Method to load the current version from version.properties.
      *
      * @return the stored string representing the current version
@@ -53,6 +44,15 @@ public class SAVersion {
     }
 
     /**
+     * Getter for the current version
+     *
+     * @return string representing the current version
+     */
+    public static String getSDKVersionNumber() {
+        return versionOverride == null ? version : versionOverride;
+    }
+
+    /**
      * Getter for a string comprising of SDK & version bundled
      *
      * @return  a string
@@ -60,7 +60,7 @@ public class SAVersion {
      */
     public static String getSDKVersion(String pluginName) {
         String pluginFormatted = pluginName != null ? String.format("_%s", pluginName) : "";
-        return String.format("%s_%s%s", getSdk(), getVersion(), pluginFormatted);
+        return String.format("%s_%s%s", getSdk(), getSDKVersionNumber(), pluginFormatted);
     }
 
     /**

--- a/superawesome-base/src/test/java/tv/superawesome/lib/saversion/TestSAVersion.kt
+++ b/superawesome-base/src/test/java/tv/superawesome/lib/saversion/TestSAVersion.kt
@@ -88,4 +88,35 @@ class TestSAVersion {
         Assert.assertEquals(sdkName, expectedSDK)
         Assert.assertTrue(isVersionNumeric)
     }
+
+    @Test
+    fun test_getSDKVersionNumber_with_version_override() {
+
+        // given
+        val expectedSDK = "5.6.7"
+        SAVersion.overrideVersion(versionOverride)
+        val sdkVersionNumber = SAVersion.getSDKVersionNumber()
+
+        // when
+        val strippedVersion = sdkVersionNumber.replace(".", "")
+        val isVersionNumeric = strippedVersion.all { char -> char.isDigit() }
+
+        // then
+        Assert.assertEquals(expectedSDK, sdkVersionNumber)
+        Assert.assertTrue(isVersionNumeric)
+    }
+
+    @Test
+    fun test_getSDKVersionNumber_defaults() {
+
+        // given
+        val sdkVersionNumber = SAVersion.getSDKVersionNumber()
+
+        // when
+        val strippedVersion = sdkVersionNumber.replace(".", "")
+        val isVersionNumeric = strippedVersion.all { char -> char.isDigit() }
+
+        // then
+        Assert.assertTrue(isVersionNumeric)
+    }
 }

--- a/superawesome-base/src/test/java/tv/superawesome/lib/saversion/TestSAVersion.kt
+++ b/superawesome-base/src/test/java/tv/superawesome/lib/saversion/TestSAVersion.kt
@@ -98,8 +98,9 @@ class TestSAVersion {
         val sdkVersionNumber = SAVersion.getSDKVersionNumber()
 
         // when
-        val strippedVersion = sdkVersionNumber.replace(".", "")
-        val isVersionNumeric = strippedVersion.all { char -> char.isDigit() }
+        val isVersionNumeric = sdkVersionNumber
+            .replace(".", "")
+            .all { char -> char.isDigit() }
 
         // then
         Assert.assertEquals(expectedSDK, sdkVersionNumber)
@@ -113,8 +114,9 @@ class TestSAVersion {
         val sdkVersionNumber = SAVersion.getSDKVersionNumber()
 
         // when
-        val strippedVersion = sdkVersionNumber.replace(".", "")
-        val isVersionNumeric = strippedVersion.all { char -> char.isDigit() }
+        val isVersionNumeric = sdkVersionNumber
+            .replace(".", "")
+            .all { char -> char.isDigit() }
 
         // then
         Assert.assertTrue(isVersionNumeric)

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/components/SdkInfo.kt
@@ -7,6 +7,7 @@ import java.util.Properties
 
 interface SdkInfoType {
     val version: String
+    val versionNumber: String
     val bundle: String
     val name: String
     val lang: String
@@ -40,6 +41,8 @@ class SdkInfo(
 
     override val version: String
         get() = overrideVersion ?: "${Keys.Platform}_${Keys.storedVersion}"
+    override val versionNumber: String
+        get() = overrideVersion ?: Keys.storedVersion
     override val bundle: String = context.packageName ?: Keys.Unknown
     override val name: String by lazy { findAppName() }
     override val lang: String = locale.toString()

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/SdkInfoTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/SdkInfoTest.kt
@@ -5,7 +5,6 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.Before
 import org.junit.Test
 import tv.superawesome.sdk.publisher.common.base.BaseTest
 import java.util.*

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/SdkInfoTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/SdkInfoTest.kt
@@ -28,6 +28,7 @@ class SdkInfoTest : BaseTest() {
         assertEquals("testAppName", sdkInfo.name)
         assertEquals("xx_YY", sdkInfo.lang)
         assertEquals("android_1.2.3", sdkInfo.version)
+        // The version number is read from the version.properties file in the test resources
         assertEquals("1.2.3", sdkInfo.versionNumber)
     }
 

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/SdkInfoTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/components/SdkInfoTest.kt
@@ -5,15 +5,46 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.Before
 import org.junit.Test
 import tv.superawesome.sdk.publisher.common.base.BaseTest
 import java.util.*
+import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 
 class SdkInfoTest : BaseTest() {
+
+    @BeforeTest
+    fun prepare() {
+        SdkInfo.Companion.overrideVersion = null
+    }
+
     @Test
     fun testSdkInfo() {
         // Given
+        val sdkInfo = configureSdkInfo()
+
+        // Then
+        assertEquals("testBundleName", sdkInfo.bundle)
+        assertEquals("testAppName", sdkInfo.name)
+        assertEquals("xx_YY", sdkInfo.lang)
+        assertEquals("android_1.2.3", sdkInfo.version)
+        assertEquals("1.2.3", sdkInfo.versionNumber)
+    }
+
+    @Test
+    fun testSdkInfo_with_version_override() {
+        // Given
+        val sdkInfo = configureSdkInfo()
+
+        // When
+        SdkInfo.Companion.overrideVersion = "4.5.6"
+
+        // Then
+        assertEquals("4.5.6", sdkInfo.versionNumber)
+    }
+
+    private fun configureSdkInfo(): SdkInfo {
         val locale = Locale("xx", "YY")
         val mockPackageManager = mockk<PackageManager> {
             every { getApplicationLabel(any()) } returns "testAppName"
@@ -26,12 +57,6 @@ class SdkInfoTest : BaseTest() {
         }
         val encoderType = Encoder()
 
-        val sdkInfo = SdkInfo(context, encoderType, locale)
-
-        // Then
-        assertEquals("testBundleName", sdkInfo.bundle)
-        assertEquals("testAppName", sdkInfo.name)
-        assertEquals("xx_YY", sdkInfo.lang)
-        assertEquals("android_1.2.3", sdkInfo.version)
+        return SdkInfo(context, encoderType, locale)
     }
 }


### PR DESCRIPTION
This PR adds a method to get the version number only for the legacy and refactored codebases