### PR TITLE
Feat/aag 2249 test callbacks

### DIFF
--- a/app/src/androidTest/java/tv/superawesome/demoapp/BannerUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/BannerUITest.kt
@@ -16,12 +16,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import tv.superawesome.demoapp.interaction.BumperInteraction
 import tv.superawesome.demoapp.interaction.CommonInteraction
-import tv.superawesome.demoapp.interaction.CommonInteraction.stubIntents
 import tv.superawesome.demoapp.interaction.ParentalGateInteraction
 import tv.superawesome.demoapp.interaction.SettingsInteraction
 import tv.superawesome.demoapp.util.ColorMatcher.matchesColor
 import tv.superawesome.demoapp.util.TestColors
 import tv.superawesome.demoapp.util.ViewTester
+import tv.superawesome.demoapp.util.WireMockHelper.stubIntents
 import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalled
 import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalledWithQueryParam
 import tv.superawesome.demoapp.util.isVisible

--- a/app/src/androidTest/java/tv/superawesome/demoapp/BannerUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/BannerUITest.kt
@@ -150,6 +150,23 @@ class BannerUITest {
             .check(isVisible())
     }
 
+    @Test
+    fun test_adClosed_callback() {
+        val placement = "88001"
+        CommonInteraction.launchActivityWithSuccessStub(placement, "banner_success.json")
+
+        CommonInteraction.clickItemAt(2)
+
+        ViewTester()
+            .waitForView(withId(R.id.bannerView))
+            .perform(waitUntil(matchesColor(TestColors.yellow)))
+
+        CommonInteraction.clickItemAt(2)
+
+        // The banner is closed automatically when a new one is opened
+        CommonInteraction.checkSubtitleContains("$placement adClosed")
+    }
+
     // Events
     @Test
     fun test_banner_impression_events() {

--- a/app/src/androidTest/java/tv/superawesome/demoapp/BannerUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/BannerUITest.kt
@@ -21,7 +21,7 @@ import tv.superawesome.demoapp.interaction.SettingsInteraction
 import tv.superawesome.demoapp.util.ColorMatcher.matchesColor
 import tv.superawesome.demoapp.util.TestColors
 import tv.superawesome.demoapp.util.ViewTester
-import tv.superawesome.demoapp.util.WireMockHelper.stubIntents
+import tv.superawesome.demoapp.util.IntentsHelper.stubIntents
 import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalled
 import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalledWithQueryParam
 import tv.superawesome.demoapp.util.isVisible

--- a/app/src/androidTest/java/tv/superawesome/demoapp/BannerUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/BannerUITest.kt
@@ -1,12 +1,9 @@
 package tv.superawesome.demoapp
 
-import android.app.Activity
-import android.app.Instrumentation
 import android.content.Intent
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -19,6 +16,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import tv.superawesome.demoapp.interaction.BumperInteraction
 import tv.superawesome.demoapp.interaction.CommonInteraction
+import tv.superawesome.demoapp.interaction.CommonInteraction.stubIntents
 import tv.superawesome.demoapp.interaction.ParentalGateInteraction
 import tv.superawesome.demoapp.interaction.SettingsInteraction
 import tv.superawesome.demoapp.util.ColorMatcher.matchesColor
@@ -28,7 +26,6 @@ import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalled
 import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalledWithQueryParam
 import tv.superawesome.demoapp.util.isVisible
 import tv.superawesome.demoapp.util.waitUntil
-
 
 @RunWith(AndroidJUnit4::class)
 @SmallTest
@@ -48,13 +45,17 @@ class BannerUITest {
 
     @Test
     fun test_adLoading() {
-        CommonInteraction.launchActivityWithSuccessStub("88001", "banner_success.json")
+        val placement = "88001"
+        CommonInteraction.launchActivityWithSuccessStub(placement, "banner_success.json")
 
         CommonInteraction.clickItemAt(2)
 
         ViewTester()
             .waitForView(withId(R.id.bannerView))
             .perform(waitUntil(matchesColor(TestColors.yellow)))
+
+        CommonInteraction.checkSubtitleContains("$placement adLoaded")
+        CommonInteraction.checkSubtitleContains("$placement adShown")
     }
 
     @Test
@@ -64,7 +65,7 @@ class BannerUITest {
 
         CommonInteraction.clickItemAt(2)
 
-        CommonInteraction.checkSubtitle("$placement adFailedToLoad")
+        CommonInteraction.checkSubtitleContains("$placement adFailedToLoad")
     }
 
     @Test
@@ -74,7 +75,7 @@ class BannerUITest {
 
         CommonInteraction.clickItemAt(2)
 
-        CommonInteraction.checkSubtitle("$placement adEmpty")
+        CommonInteraction.checkSubtitleContains("$placement adEmpty")
     }
 
     @Test
@@ -178,8 +179,10 @@ class BannerUITest {
     @Test
     fun test_banner_click_event() {
         // Given
+        stubIntents()
+        val placement = "88001"
         CommonInteraction.launchActivityWithSuccessStub(
-            "88001",
+            placement,
             "banner_success.json"
         )
         CommonInteraction.clickItemAt(2)
@@ -190,6 +193,7 @@ class BannerUITest {
             .perform(click())
 
         // Then
+        CommonInteraction.checkSubtitleContains("$placement adClicked")
         verifyUrlPathCalled("/click")
     }
 
@@ -214,12 +218,7 @@ class BannerUITest {
     @Test
     fun test_external_webpage_opening_on_click() {
         // Given
-        intending(hasAction(Intent.ACTION_VIEW)).respondWith(
-            Instrumentation.ActivityResult(
-                Activity.RESULT_OK,
-                Intent()
-            )
-        )
+        stubIntents()
         val placement = "88001"
         CommonInteraction.launchActivityWithSuccessStub(placement, "banner_success.json")
         CommonInteraction.clickPlacementById(placement)

--- a/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
@@ -21,7 +21,7 @@ import tv.superawesome.demoapp.interaction.ParentalGateInteraction
 import tv.superawesome.demoapp.interaction.SettingsInteraction
 import tv.superawesome.demoapp.util.TestColors
 import tv.superawesome.demoapp.util.ViewTester
-import tv.superawesome.demoapp.util.WireMockHelper.stubIntents
+import tv.superawesome.demoapp.util.IntentsHelper.stubIntents
 import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalled
 import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalledWithQueryParam
 import tv.superawesome.demoapp.util.isVisible

--- a/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
@@ -216,6 +216,34 @@ class InterstitialUITest {
             .check(isVisible())
     }
 
+    @Test
+    fun test_standard_adAlreadyLoaded_callback() {
+        val placement = "87892"
+
+        CommonInteraction.launchActivityWithSuccessStub(placement, "interstitial_standard_success.json") {
+            SettingsInteraction.disablePlay()
+        }
+
+        CommonInteraction.clickItemAt(5)
+        CommonInteraction.clickItemAt(5)
+
+        CommonInteraction.checkSubtitleContains("$placement adAlreadyLoaded")
+    }
+
+    @Test
+    fun test_ksf_adAlreadyLoaded_callback() {
+        val placement = "87970"
+
+        CommonInteraction.launchActivityWithSuccessStub(placement, "interstitial_ksf_success.json") {
+            SettingsInteraction.disablePlay()
+        }
+
+        CommonInteraction.clickItemAt(8)
+        CommonInteraction.clickItemAt(8)
+
+        CommonInteraction.checkSubtitleContains("$placement adAlreadyLoaded")
+    }
+
     // Events
     @Test
     fun test_standard_ad_impression_events() {

--- a/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 import tv.superawesome.demoapp.interaction.AdInteraction.testAdLoading
 import tv.superawesome.demoapp.interaction.BumperInteraction
 import tv.superawesome.demoapp.interaction.CommonInteraction
+import tv.superawesome.demoapp.interaction.CommonInteraction.stubIntents
 import tv.superawesome.demoapp.interaction.ParentalGateInteraction
 import tv.superawesome.demoapp.interaction.SettingsInteraction
 import tv.superawesome.demoapp.util.TestColors
@@ -183,6 +184,7 @@ class InterstitialUITest {
     fun test_bumper_enabled_from_api() {
         // Given bumper page is enabled from api
         val placement = "87892"
+        stubIntents()
         CommonInteraction.launchActivityWithSuccessStub(
             placement,
             "interstitial_standard_enabled_success.json"
@@ -305,12 +307,7 @@ class InterstitialUITest {
     @Test
     fun test_external_webpage_opening_on_click() {
         // Given
-        Intents.intending(IntentMatchers.hasAction(Intent.ACTION_VIEW)).respondWith(
-            Instrumentation.ActivityResult(
-                Activity.RESULT_OK,
-                Intent()
-            )
-        )
+        stubIntents()
         val placement = "87892"
         CommonInteraction.launchActivityWithSuccessStub(
             placement,

--- a/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
@@ -47,7 +47,7 @@ class InterstitialUITest {
     fun test_standard_adLoading() {
         val placement = "87892"
         testAdLoading(
-            "87892",
+            placement,
             "interstitial_standard_success.json",
             5,
             TestColors.yellow

--- a/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
@@ -1,7 +1,5 @@
 package tv.superawesome.demoapp
 
-import android.app.Activity
-import android.app.Instrumentation
 import android.content.Intent
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -19,11 +17,11 @@ import org.junit.runner.RunWith
 import tv.superawesome.demoapp.interaction.AdInteraction.testAdLoading
 import tv.superawesome.demoapp.interaction.BumperInteraction
 import tv.superawesome.demoapp.interaction.CommonInteraction
-import tv.superawesome.demoapp.interaction.CommonInteraction.stubIntents
 import tv.superawesome.demoapp.interaction.ParentalGateInteraction
 import tv.superawesome.demoapp.interaction.SettingsInteraction
 import tv.superawesome.demoapp.util.TestColors
 import tv.superawesome.demoapp.util.ViewTester
+import tv.superawesome.demoapp.util.WireMockHelper.stubIntents
 import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalled
 import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalledWithQueryParam
 import tv.superawesome.demoapp.util.isVisible
@@ -267,7 +265,7 @@ class InterstitialUITest {
     fun test_standard_ad_click_event() {
         // Given
         val placement = "87892"
-        CommonInteraction.stubIntents()
+        stubIntents()
         CommonInteraction.launchActivityWithSuccessStub(
             placement,
             "interstitial_standard_success.json"

--- a/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
@@ -46,22 +46,40 @@ class InterstitialUITest {
 
     @Test
     fun test_standard_adLoading() {
+        val placement = "87892"
         testAdLoading(
             "87892",
             "interstitial_standard_success.json",
             5,
             TestColors.yellow
         )
+
+        ViewTester()
+            .waitForView(withContentDescription("Close"))
+            .perform(waitUntil(isDisplayed()))
+            .perform(click())
+
+        CommonInteraction.checkSubtitleContains("$placement adLoaded")
+        CommonInteraction.checkSubtitleContains("$placement adShown")
     }
 
     @Test
     fun test_ksf_adLoading() {
+        val placement = "87970"
         testAdLoading(
-            "87970",
+            placement,
             "interstitial_ksf_success.json",
             8,
             TestColors.ksfYellow
         )
+
+        ViewTester()
+            .waitForView(withContentDescription("Close"))
+            .perform(waitUntil(isDisplayed()))
+            .perform(click())
+
+        CommonInteraction.checkSubtitleContains("$placement adLoaded")
+        CommonInteraction.checkSubtitleContains("$placement adShown")
     }
 
     @Test
@@ -101,8 +119,9 @@ class InterstitialUITest {
 
     @Test
     fun test_standard_CloseButton() {
+        val placement = "87892"
         CommonInteraction.launchActivityWithSuccessStub(
-            "87892",
+            placement,
             "interstitial_standard_success.json"
         )
 
@@ -112,11 +131,15 @@ class InterstitialUITest {
             .waitForView(withContentDescription("Close"))
             .perform(waitUntil(isDisplayed()))
             .check(isVisible())
+            .perform(click())
+
+        CommonInteraction.checkSubtitleContains("$placement adClosed")
     }
 
     @Test
     fun test_ksf_CloseButton() {
-        CommonInteraction.launchActivityWithSuccessStub("87970", "interstitial_ksf_success.json")
+        val placement = "87970"
+        CommonInteraction.launchActivityWithSuccessStub(placement, "interstitial_ksf_success.json")
 
         CommonInteraction.clickItemAt(8)
 
@@ -124,6 +147,9 @@ class InterstitialUITest {
             .waitForView(withContentDescription("Close"))
             .perform(waitUntil(isDisplayed()))
             .check(isVisible())
+            .perform(click())
+
+        CommonInteraction.checkSubtitleContains("$placement adClosed")
     }
 
     @Test
@@ -238,16 +264,23 @@ class InterstitialUITest {
     @Test
     fun test_standard_ad_click_event() {
         // Given
+        val placement = "87892"
+        CommonInteraction.stubIntents()
         CommonInteraction.launchActivityWithSuccessStub(
-            "87892",
+            placement,
             "interstitial_standard_success.json"
         )
         CommonInteraction.clickItemAt(5)
 
         // When
         onView(withContentDescription("Ad content")).perform(click())
+        ViewTester()
+            .waitForView(withContentDescription("Close"))
+            .perform(waitUntil(isDisplayed()))
+            .perform(click())
 
         // Then
+        CommonInteraction.checkSubtitleContains("$placement adClicked")
         verifyUrlPathCalled("/click")
     }
 

--- a/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/InterstitialUITest.kt
@@ -71,7 +71,7 @@ class InterstitialUITest {
 
         CommonInteraction.clickItemAt(8)
 
-        CommonInteraction.checkSubtitle("$placement adFailedToLoad")
+        CommonInteraction.checkSubtitleContains("$placement adFailedToLoad")
     }
 
     @Test
@@ -81,7 +81,7 @@ class InterstitialUITest {
 
         CommonInteraction.clickItemAt(8)
 
-        CommonInteraction.checkSubtitle("$placement adEmpty")
+        CommonInteraction.checkSubtitleContains("$placement adEmpty")
     }
 
     @Test

--- a/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
@@ -168,7 +168,7 @@ class VideoAdUITest {
 
         CommonInteraction.clickItemAt(13)
 
-        CommonInteraction.checkSubtitle("$placement adFailedToLoad")
+        CommonInteraction.checkSubtitleContains("$placement adFailedToLoad")
     }
 
     @Test
@@ -178,7 +178,7 @@ class VideoAdUITest {
 
         CommonInteraction.clickItemAt(13)
 
-        CommonInteraction.checkSubtitle("$placement adEmpty")
+        CommonInteraction.checkSubtitleContains("$placement adEmpty")
     }
 
     @Test

--- a/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
@@ -45,7 +45,8 @@ class VideoAdUITest {
 
     @Test
     fun test_standard_CloseButtonWithNoDelay() {
-        CommonInteraction.launchActivityWithSuccessStub("87969", "video_direct_success.json") {
+        val placement = "87969"
+        CommonInteraction.launchActivityWithSuccessStub(placement, "video_direct_success.json") {
             SettingsInteraction.closeNoDelay()
         }
 
@@ -55,13 +56,16 @@ class VideoAdUITest {
             .waitForView(withContentDescription("Close"))
             .perform(waitUntil(isDisplayed()))
             .check(isVisible())
+            .perform(click())
 
+        CommonInteraction.checkSubtitleContains("$placement adClosed")
         verifyUrlPathCalled("/moat")
     }
 
     @Test
     fun test_standard_CloseButtonWithDelay() {
-        CommonInteraction.launchActivityWithSuccessStub("87969", "video_direct_success.json") {
+        val placement = "87969"
+        CommonInteraction.launchActivityWithSuccessStub(placement, "video_direct_success.json") {
             SettingsInteraction.closeDelayed()
         }
 
@@ -72,14 +76,17 @@ class VideoAdUITest {
             .check(isGone())
             .perform(waitUntil(isDisplayed()))
             .check(isVisible())
+            .perform(click())
 
+        CommonInteraction.checkSubtitleContains("$placement adClosed")
         verifyUrlPathCalled("/moat")
         verifyUrlPathCalled("/event")
     }
 
     @Test
     fun test_vast_CloseButtonWithNoDelay() {
-        CommonInteraction.launchActivityWithSuccessStub("88406", "video_vast_success.json") {
+        val placement = "88406"
+        CommonInteraction.launchActivityWithSuccessStub(placement, "video_vast_success.json") {
             SettingsInteraction.closeNoDelay()
         }
 
@@ -89,11 +96,16 @@ class VideoAdUITest {
             .waitForView(withContentDescription("Close"))
             .perform(waitUntil(isDisplayed()))
             .check(isVisible())
+            .perform(click())
+
+        CommonInteraction.checkSubtitleContains("$placement adClosed")
     }
 
     @Test
     fun test_vast_CloseButtonWithDelay() {
-        CommonInteraction.launchActivityWithSuccessStub("88406", "video_vast_success.json") {
+        val placement = "88406"
+        stubVASTPaths()
+        CommonInteraction.launchActivityWithSuccessStub(placement, "video_vast_success.json") {
             SettingsInteraction.closeDelayed()
         }
 
@@ -104,11 +116,16 @@ class VideoAdUITest {
             .check(isGone())
             .perform(waitUntil(isDisplayed()))
             .check(isVisible())
+            .perform(click())
+
+        CommonInteraction.checkSubtitleContains("$placement adClosed")
     }
 
     @Test
     fun test_vpaid_CloseButton() {
-        CommonInteraction.launchActivityWithSuccessStub("89056", "video_vpaid_success.json")
+        val placement = "89056"
+        stubVASTPaths()
+        CommonInteraction.launchActivityWithSuccessStub(placement, "video_vpaid_success.json")
 
         CommonInteraction.clickItemAt(12)
 
@@ -116,49 +133,86 @@ class VideoAdUITest {
             .waitForView(withContentDescription("Close"))
             .perform(waitUntil(isDisplayed()))
             .check(isVisible())
+            .perform(click())
+
+        CommonInteraction.checkSubtitleContains("$placement adClosed")
     }
 
     @Test
     fun test_auto_close_on_finish() {
-        testAdLoading(
-            "87969",
-            "video_direct_success.json",
-            13,
-            TestColors.directYellow
+        val placement = "87969"
+        stubVASTPaths()
+
+        CommonInteraction.launchActivityWithSuccessStub(
+            placement, "video_direct_success.json"
         )
+
+        CommonInteraction.clickItemAt(13)
+
         ViewTester()
             .waitForView(withId(R.id.subtitleTextView))
             .perform(waitUntil(isDisplayed()))
+
+        CommonInteraction.checkSubtitleContains("$placement adEnded", 20000)
     }
 
     @Test
     fun test_vast_adLoading() {
+        val placement = "88406"
+        stubVASTPaths()
         testAdLoading(
-            "88406",
+            placement,
             "video_vast_success.json",
             11,
             TestColors.vastYellow
         )
+
+        ViewTester()
+            .waitForView(withContentDescription("Close"))
+            .perform(waitUntil(isDisplayed()))
+            .perform(click())
+
+        CommonInteraction.checkSubtitleContains("$placement adLoaded")
+        CommonInteraction.checkSubtitleContains("$placement adShown")
     }
 
     @Test
     fun test_vpaid_adLoading() {
+        val placement = "89056"
+        stubVASTPaths()
         testAdLoading(
-            "89056",
+            placement,
             "video_vpaid_success.json",
             12,
             TestColors.vpaidYellow
         )
+
+        ViewTester()
+            .waitForView(withContentDescription("Close"))
+            .perform(waitUntil(isDisplayed()))
+            .perform(click())
+
+        CommonInteraction.checkSubtitleContains("$placement adLoaded")
+        CommonInteraction.checkSubtitleContains("$placement adShown")
     }
 
     @Test
     fun test_direct_adLoading() {
+        val placement = "87969"
         testAdLoading(
             "87969",
             "video_direct_success.json",
             13,
             TestColors.directYellow
         )
+
+        ViewTester()
+            .waitForView(withContentDescription("Close"))
+            .perform(waitUntil(isDisplayed()))
+            .perform(click())
+
+        CommonInteraction.checkSubtitleContains("$placement adLoaded")
+        CommonInteraction.checkSubtitleContains("$placement adShown")
     }
 
     @Test

--- a/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
@@ -47,6 +47,7 @@ class VideoAdUITest {
     @Test
     fun test_standard_CloseButtonWithNoDelay() {
         val placement = "87969"
+        stubVASTPaths()
         CommonInteraction.launchActivityWithSuccessStub(placement, "video_direct_success.json") {
             SettingsInteraction.closeNoDelay()
         }
@@ -66,6 +67,7 @@ class VideoAdUITest {
     @Test
     fun test_standard_CloseButtonWithDelay() {
         val placement = "87969"
+        stubVASTPaths()
         CommonInteraction.launchActivityWithSuccessStub(placement, "video_direct_success.json") {
             SettingsInteraction.closeDelayed()
         }
@@ -87,6 +89,7 @@ class VideoAdUITest {
     @Test
     fun test_vast_CloseButtonWithNoDelay() {
         val placement = "88406"
+        stubVASTPaths()
         CommonInteraction.launchActivityWithSuccessStub(placement, "video_vast_success.json") {
             SettingsInteraction.closeNoDelay()
         }
@@ -194,12 +197,12 @@ class VideoAdUITest {
             .perform(click())
 
         CommonInteraction.checkSubtitleContains("$placement adLoaded")
-        CommonInteraction.checkSubtitleContains("$placement adShown")
     }
 
     @Test
     fun test_direct_adLoading() {
         val placement = "87969"
+        stubVASTPaths()
         testAdLoading(
             "87969",
             "video_direct_success.json",
@@ -270,6 +273,7 @@ class VideoAdUITest {
     fun test_bumper_enabled_from_settings() {
         // Given bumper page is enabled from settings
         val placement = "87969"
+        stubVASTPaths()
         CommonInteraction.launchActivityWithSuccessStub(
             placement,
             "video_direct_success.json"
@@ -411,6 +415,7 @@ class VideoAdUITest {
     @Test
     fun test_direct_ad_dwell_time() {
         // Given
+        stubVASTPaths()
         CommonInteraction.launchActivityWithSuccessStub(
             "87969",
             "video_direct_success.json"
@@ -533,6 +538,7 @@ class VideoAdUITest {
             )
         )
         val placement = "87969"
+        stubVASTPaths()
         CommonInteraction.launchActivityWithSuccessStub(
             placement,
             "video_direct_success.json"

--- a/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
@@ -157,7 +157,7 @@ class VideoAdUITest {
             .waitForView(withId(R.id.subtitleTextView))
             .perform(waitUntil(isDisplayed()))
 
-        CommonInteraction.checkSubtitleContains("$placement adEnded", 20000)
+        CommonInteraction.checkSubtitleContains("$placement adEnded")
     }
 
     @Test

--- a/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
@@ -23,7 +23,7 @@ import tv.superawesome.demoapp.interaction.CommonInteraction
 import tv.superawesome.demoapp.interaction.ParentalGateInteraction
 import tv.superawesome.demoapp.interaction.SettingsInteraction
 import tv.superawesome.demoapp.util.*
-import tv.superawesome.demoapp.util.WireMockHelper.stubIntents
+import tv.superawesome.demoapp.util.IntentsHelper.stubIntents
 import tv.superawesome.demoapp.util.WireMockHelper.stubVASTPaths
 import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalled
 import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalledWithQueryParam

--- a/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith
 import tv.superawesome.demoapp.interaction.AdInteraction.testAdLoading
 import tv.superawesome.demoapp.interaction.BumperInteraction
 import tv.superawesome.demoapp.interaction.CommonInteraction
+import tv.superawesome.demoapp.interaction.CommonInteraction.stubIntents
 import tv.superawesome.demoapp.interaction.ParentalGateInteraction
 import tv.superawesome.demoapp.interaction.SettingsInteraction
 import tv.superawesome.demoapp.util.*
@@ -380,11 +381,15 @@ class VideoAdUITest {
     @Test
     fun test_direct_ad_click_event() {
         // Given
+        val placement = "87969"
         stubVASTPaths()
+        stubIntents()
         CommonInteraction.launchActivityWithSuccessStub(
-            "87969",
+            placement,
             "video_direct_success.json"
-        )
+        ) {
+            SettingsInteraction.closeNoDelay()
+        }
         CommonInteraction.clickItemAt(13)
 
         // When
@@ -393,8 +398,14 @@ class VideoAdUITest {
             .perform(waitUntil(isDisplayed()))
             .perform(click())
 
+        ViewTester()
+            .waitForView(withContentDescription("Close"))
+            .perform(waitUntil(isDisplayed()))
+            .perform(click())
+
         // Then
         verifyUrlPathCalled("/vast/click")
+        CommonInteraction.checkSubtitleContains("$placement adClicked")
     }
 
     @Test
@@ -444,11 +455,15 @@ class VideoAdUITest {
     @Test
     fun test_vast_ad_click_event() {
         // Given
+        val placement = "88406"
+        stubIntents()
         stubVASTPaths()
         CommonInteraction.launchActivityWithSuccessStub(
-            "88406",
+            placement,
             "video_vast_success.json"
-        )
+        ) {
+            SettingsInteraction.closeNoDelay()
+        }
 
         CommonInteraction.clickItemAt(11)
 
@@ -458,8 +473,14 @@ class VideoAdUITest {
             .perform(waitUntil(isDisplayed()))
             .perform(click())
 
+        ViewTester()
+            .waitForView(withContentDescription("Close"))
+            .perform(waitUntil(isDisplayed()))
+            .perform(click())
+
         // Then
         verifyUrlPathCalled("/vast/click")
+        CommonInteraction.checkSubtitleContains("$placement adClicked")
     }
 
     @Test

--- a/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
@@ -20,10 +20,10 @@ import org.junit.runner.RunWith
 import tv.superawesome.demoapp.interaction.AdInteraction.testAdLoading
 import tv.superawesome.demoapp.interaction.BumperInteraction
 import tv.superawesome.demoapp.interaction.CommonInteraction
-import tv.superawesome.demoapp.interaction.CommonInteraction.stubIntents
 import tv.superawesome.demoapp.interaction.ParentalGateInteraction
 import tv.superawesome.demoapp.interaction.SettingsInteraction
 import tv.superawesome.demoapp.util.*
+import tv.superawesome.demoapp.util.WireMockHelper.stubIntents
 import tv.superawesome.demoapp.util.WireMockHelper.stubVASTPaths
 import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalled
 import tv.superawesome.demoapp.util.WireMockHelper.verifyUrlPathCalledWithQueryParam

--- a/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/VideoAdUITest.kt
@@ -355,6 +355,48 @@ class VideoAdUITest {
             .check(isVisible())
     }
 
+    @Test
+    fun test_direct_adAlreadyLoaded_callback() {
+        val placement = "87969"
+        stubVASTPaths()
+        CommonInteraction.launchActivityWithSuccessStub(placement, "video_direct_success.json") {
+            SettingsInteraction.disablePlay()
+        }
+
+        CommonInteraction.clickItemAt(13)
+        CommonInteraction.clickItemAt(13)
+
+        CommonInteraction.checkSubtitleContains("$placement adAlreadyLoaded")
+    }
+
+    @Test
+    fun test_vast_adAlreadyLoaded_callback() {
+        val placement = "88406"
+        stubVASTPaths()
+        CommonInteraction.launchActivityWithSuccessStub(placement, "video_vast_success.json") {
+            SettingsInteraction.disablePlay()
+        }
+
+        CommonInteraction.clickItemAt(11)
+        CommonInteraction.clickItemAt(11)
+
+        CommonInteraction.checkSubtitleContains("$placement adAlreadyLoaded")
+    }
+
+    @Test
+    fun test_vpaid_adAlreadyLoaded_callback() {
+        val placement = "89056"
+        stubVASTPaths()
+        CommonInteraction.launchActivityWithSuccessStub(placement, "video_vpaid_success.json") {
+            SettingsInteraction.disablePlay()
+        }
+
+        CommonInteraction.clickItemAt(12)
+        CommonInteraction.clickItemAt(12)
+
+        CommonInteraction.checkSubtitleContains("$placement adAlreadyLoaded")
+    }
+
     // Events
     @Test
     fun test_direct_ad_impression_events() {

--- a/app/src/androidTest/java/tv/superawesome/demoapp/interaction/CommonInteraction.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/interaction/CommonInteraction.kt
@@ -62,7 +62,7 @@ object CommonInteraction {
             .check(matches(withText(text)))
     }
 
-    fun checkSubtitleContains(text: String, timeout: Long = 5000) {
+    fun checkSubtitleContains(text: String) {
         onView(withId(R.id.subtitleTextView))
             .perform(waitUntil(isDisplayed()))
             .perform(waitUntil(withSubstring(text)))

--- a/app/src/androidTest/java/tv/superawesome/demoapp/interaction/CommonInteraction.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/interaction/CommonInteraction.kt
@@ -1,12 +1,23 @@
 package tv.superawesome.demoapp.interaction
 
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import android.view.View
+import android.widget.TextView
 import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso.onData
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.PerformException
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.util.HumanReadables
+import org.hamcrest.Matcher
 import org.hamcrest.Matchers.anything
 import tv.superawesome.demoapp.MainActivity
 import tv.superawesome.demoapp.R
@@ -14,6 +25,7 @@ import tv.superawesome.demoapp.util.AdapterUtil
 import tv.superawesome.demoapp.util.WireMockHelper.stubCommonPaths
 import tv.superawesome.demoapp.util.WireMockHelper.stubFailure
 import tv.superawesome.demoapp.util.WireMockHelper.stubSuccess
+import java.util.concurrent.TimeoutException
 
 object CommonInteraction {
     fun launchActivityWithSuccessStub(
@@ -59,5 +71,45 @@ object CommonInteraction {
     fun checkSubtitle(text: String) {
         onView(withId(R.id.subtitleTextView))
             .check(matches(withText(text)))
+    }
+
+    fun checkSubtitleContains(text: String, timeout: Long = 5000) {
+        onView(withId(R.id.subtitleTextView))
+            .perform(waitForText(text, timeout))
+    }
+
+    fun waitForText(text: String, timeout: Long): ViewAction = object : ViewAction {
+
+        override fun getConstraints(): Matcher<View> {
+            return isAssignableFrom(TextView::class.java)
+        }
+
+        override fun getDescription(): String {
+            return "wait up to $timeout milliseconds for the view to have text $text"
+        }
+
+        override fun perform(uiController: UiController?, view: View?) {
+            val endTime = System.currentTimeMillis() + timeout
+
+            do {
+                if ((view as? TextView)?.text?.contains(text) == true) return
+                with(uiController) { this?.loopMainThreadForAtLeast(50) }
+            } while (System.currentTimeMillis() < endTime)
+
+            throw PerformException.Builder()
+                .withActionDescription(description)
+                .withCause(TimeoutException("Waited $timeout milliseconds"))
+                .withViewDescription(HumanReadables.describe(view))
+                .build()
+        }
+    }
+
+    fun stubIntents() {
+        Intents.intending(IntentMatchers.hasAction(Intent.ACTION_VIEW)).respondWith(
+            Instrumentation.ActivityResult(
+                Activity.RESULT_OK,
+                Intent()
+            )
+        )
     }
 }

--- a/app/src/androidTest/java/tv/superawesome/demoapp/interaction/CommonInteraction.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/interaction/CommonInteraction.kt
@@ -25,6 +25,7 @@ import tv.superawesome.demoapp.util.AdapterUtil
 import tv.superawesome.demoapp.util.WireMockHelper.stubCommonPaths
 import tv.superawesome.demoapp.util.WireMockHelper.stubFailure
 import tv.superawesome.demoapp.util.WireMockHelper.stubSuccess
+import tv.superawesome.demoapp.util.waitUntil
 import java.util.concurrent.TimeoutException
 
 object CommonInteraction {
@@ -70,11 +71,13 @@ object CommonInteraction {
 
     fun checkSubtitle(text: String) {
         onView(withId(R.id.subtitleTextView))
+            .perform(waitUntil(isDisplayed()))
             .check(matches(withText(text)))
     }
 
     fun checkSubtitleContains(text: String, timeout: Long = 5000) {
         onView(withId(R.id.subtitleTextView))
+            .perform(waitUntil(isDisplayed()))
             .perform(waitForText(text, timeout))
     }
 

--- a/app/src/androidTest/java/tv/superawesome/demoapp/interaction/CommonInteraction.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/interaction/CommonInteraction.kt
@@ -1,18 +1,11 @@
 package tv.superawesome.demoapp.interaction
 
-import android.view.View
-import android.widget.TextView
 import androidx.test.core.app.launchActivity
 import androidx.test.espresso.Espresso.onData
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.PerformException
-import androidx.test.espresso.UiController
-import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
-import androidx.test.espresso.util.HumanReadables
-import org.hamcrest.Matcher
 import org.hamcrest.Matchers.anything
 import tv.superawesome.demoapp.MainActivity
 import tv.superawesome.demoapp.R
@@ -21,7 +14,6 @@ import tv.superawesome.demoapp.util.WireMockHelper.stubCommonPaths
 import tv.superawesome.demoapp.util.WireMockHelper.stubFailure
 import tv.superawesome.demoapp.util.WireMockHelper.stubSuccess
 import tv.superawesome.demoapp.util.waitUntil
-import java.util.concurrent.TimeoutException
 
 object CommonInteraction {
     fun launchActivityWithSuccessStub(

--- a/app/src/androidTest/java/tv/superawesome/demoapp/interaction/CommonInteraction.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/interaction/CommonInteraction.kt
@@ -1,8 +1,5 @@
 package tv.superawesome.demoapp.interaction
 
-import android.app.Activity
-import android.app.Instrumentation
-import android.content.Intent
 import android.view.View
 import android.widget.TextView
 import androidx.test.core.app.launchActivity
@@ -13,8 +10,6 @@ import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.espresso.util.HumanReadables
 import org.hamcrest.Matcher
@@ -105,14 +100,5 @@ object CommonInteraction {
                 .withViewDescription(HumanReadables.describe(view))
                 .build()
         }
-    }
-
-    fun stubIntents() {
-        Intents.intending(IntentMatchers.hasAction(Intent.ACTION_VIEW)).respondWith(
-            Instrumentation.ActivityResult(
-                Activity.RESULT_OK,
-                Intent()
-            )
-        )
     }
 }

--- a/app/src/androidTest/java/tv/superawesome/demoapp/interaction/CommonInteraction.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/interaction/CommonInteraction.kt
@@ -73,32 +73,6 @@ object CommonInteraction {
     fun checkSubtitleContains(text: String, timeout: Long = 5000) {
         onView(withId(R.id.subtitleTextView))
             .perform(waitUntil(isDisplayed()))
-            .perform(waitForText(text, timeout))
-    }
-
-    fun waitForText(text: String, timeout: Long): ViewAction = object : ViewAction {
-
-        override fun getConstraints(): Matcher<View> {
-            return isAssignableFrom(TextView::class.java)
-        }
-
-        override fun getDescription(): String {
-            return "wait up to $timeout milliseconds for the view to have text $text"
-        }
-
-        override fun perform(uiController: UiController?, view: View?) {
-            val endTime = System.currentTimeMillis() + timeout
-
-            do {
-                if ((view as? TextView)?.text?.contains(text) == true) return
-                with(uiController) { this?.loopMainThreadForAtLeast(50) }
-            } while (System.currentTimeMillis() < endTime)
-
-            throw PerformException.Builder()
-                .withActionDescription(description)
-                .withCause(TimeoutException("Waited $timeout milliseconds"))
-                .withViewDescription(HumanReadables.describe(view))
-                .build()
-        }
+            .perform(waitUntil(withSubstring(text)))
     }
 }

--- a/app/src/androidTest/java/tv/superawesome/demoapp/interaction/SettingsInteraction.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/interaction/SettingsInteraction.kt
@@ -38,6 +38,11 @@ object SettingsInteraction {
             .perform(click())
     }
 
+    fun disablePlay() {
+        onView(withId(R.id.playbackDisableButton))
+            .perform(click())
+    }
+
     fun closeSettings() {
         onView(withId(R.id.closeButton))
             .perform(click())

--- a/app/src/androidTest/java/tv/superawesome/demoapp/util/IntentsHelper.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/util/IntentsHelper.kt
@@ -1,0 +1,19 @@
+package tv.superawesome.demoapp.util
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
+
+object IntentsHelper {
+
+    fun stubIntents() {
+        Intents.intending(IntentMatchers.hasAction(Intent.ACTION_VIEW)).respondWith(
+            Instrumentation.ActivityResult(
+                Activity.RESULT_OK,
+                Intent()
+            )
+        )
+    }
+}

--- a/app/src/androidTest/java/tv/superawesome/demoapp/util/WireMockHelper.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/util/WireMockHelper.kt
@@ -1,5 +1,10 @@
 package tv.superawesome.demoapp.util
 
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
 import com.github.tomakehurst.wiremock.client.WireMock.*
 
 object WireMockHelper {
@@ -87,6 +92,15 @@ object WireMockHelper {
                         .withStatus(200)
                         .withBody("")
                 )
+        )
+    }
+
+    fun stubIntents() {
+        Intents.intending(IntentMatchers.hasAction(Intent.ACTION_VIEW)).respondWith(
+            Instrumentation.ActivityResult(
+                Activity.RESULT_OK,
+                Intent()
+            )
         )
     }
 

--- a/app/src/androidTest/java/tv/superawesome/demoapp/util/WireMockHelper.kt
+++ b/app/src/androidTest/java/tv/superawesome/demoapp/util/WireMockHelper.kt
@@ -1,10 +1,5 @@
 package tv.superawesome.demoapp.util
 
-import android.app.Activity
-import android.app.Instrumentation
-import android.content.Intent
-import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.matcher.IntentMatchers
 import com.github.tomakehurst.wiremock.client.WireMock.*
 
 object WireMockHelper {
@@ -92,15 +87,6 @@ object WireMockHelper {
                         .withStatus(200)
                         .withBody("")
                 )
-        )
-    }
-
-    fun stubIntents() {
-        Intents.intending(IntentMatchers.hasAction(Intent.ACTION_VIEW)).respondWith(
-            Instrumentation.ActivityResult(
-                Activity.RESULT_OK,
-                Intent()
-            )
         )
     }
 

--- a/app/src/androidTest/resources/banner_success.json
+++ b/app/src/androidTest/resources/banner_success.json
@@ -33,7 +33,7 @@
     "bumper": false,
     "attributionType": 1,
     "vpaid": false,
-    "click_url": "undefined"
+    "click_url": "https://www.popjam.com"
   },
   "is_fill": false,
   "is_fallback": false,

--- a/app/src/androidTest/resources/interstitial_standard_enabled_success.json
+++ b/app/src/androidTest/resources/interstitial_standard_enabled_success.json
@@ -33,7 +33,7 @@
     "bumper": true,
     "attributionType": 1,
     "vpaid": false,
-    "click_url": "undefined"
+    "click_url": "http://www.popjam.com"
   },
   "is_fill": false,
   "is_fallback": false,

--- a/app/src/androidTest/resources/interstitial_standard_success.json
+++ b/app/src/androidTest/resources/interstitial_standard_success.json
@@ -33,7 +33,7 @@
     "bumper": false,
     "attributionType": 1,
     "vpaid": false,
-    "click_url": "undefined"
+    "click_url": "https://www.popjam.com"
   },
   "is_fill": false,
   "is_fallback": false,

--- a/app/src/androidTest/resources/video_direct_enabled_success.json
+++ b/app/src/androidTest/resources/video_direct_enabled_success.json
@@ -29,7 +29,7 @@
         }
       ],
       "duration": 10,
-      "vast": "https://eu-west-1-ads.superawesome.tv/v2/video/vast/87969/181342/512633/?sdkVersion=unknown&rnd=c2619ad3-6138-4432-a6ef-5c1bd86af6d1&bundle=com.superawesome&device=web&country=TR&flow=normal&aua=eyJhbGciOiJIUzI1NiJ9.TW96aWxsYS81LjAgKFdpbmRvd3MgTlQgMTAuMDsgV2luNjQ7IHg2NCkgQXBwbGVXZWJLaXQvNTM3LjM2IChLSFRNTCwgbGlrZSBHZWNrbykgQ2hyb21lLzgzLjAuNDEwMy45NyBTYWZhcmkvNTM3LjM2.fNi_jam5Bd9ip_c68rVpQWyuOY_Az3Jsv05mC2mCsnM&tip=eyJhbGciOiJIUzI1NiJ9.NS4xNzYuMS4w.yJa6mBEUD_t7rLsGQBfEcpAa8xfPYR4nL3SzR_JDKf4"
+      "vast": "http://localhost:8080/vast/tag"
     },
     "bumper": true
   },

--- a/app/src/androidTest/resources/video_direct_success.json
+++ b/app/src/androidTest/resources/video_direct_success.json
@@ -29,7 +29,7 @@
       "width": 600,
       "height": 480,
       "duration": 10,
-      "vast": "https://eu-west-1-ads.superawesome.tv/v2/video/vast/87969/181342/512633/?sdkVersion=unknown&rnd=76735278-a7ad-417d-9534-e50466f301ed&bundle=com.superawesome&device=web&country=GB&flow=normal&aua=eyJhbGciOiJIUzI1NiJ9.TW96aWxsYS81LjAgKFdpbmRvd3MgTlQgMTAuMDsgV2luNjQ7IHg2NCkgQXBwbGVXZWJLaXQvNTM3LjM2IChLSFRNTCwgbGlrZSBHZWNrbykgQ2hyb21lLzgzLjAuNDEwMy45NyBTYWZhcmkvNTM3LjM2.fNi_jam5Bd9ip_c68rVpQWyuOY_Az3Jsv05mC2mCsnM&tip=eyJhbGciOiJIUzI1NiJ9.OTAuMjU0LjI1LjA.VeY1NyHYwSXlTJbVgPkkAmPx4buBj8VB7IjHHtcIVHs"
+      "vast": "http://localhost:8080/vast/tag"
     },
     "click_url": "https://www.popjam.com/"
   },

--- a/app/src/androidTest/resources/video_vpaid_success.json
+++ b/app/src/androidTest/resources/video_vpaid_success.json
@@ -9,7 +9,7 @@
       "width": 600,
       "height": 480,
       "duration": 0,
-      "vast": "https://eu-west-1-ads.superawesome.tv/v2/video/vast/89056/182932/510371/?sdkVersion=unknown&rnd=cb5916c5-e947-4d21-9624-17d369876841&bundle=com.superawesome&device=web&country=TR&flow=normal&aua=eyJhbGciOiJIUzI1NiJ9.TW96aWxsYS81LjAgKFdpbmRvd3MgTlQgMTAuMDsgV2luNjQ7IHg2NCkgQXBwbGVXZWJLaXQvNTM3LjM2IChLSFRNTCwgbGlrZSBHZWNrbykgQ2hyb21lLzgzLjAuNDEwMy45NyBTYWZhcmkvNTM3LjM2.fNi_jam5Bd9ip_c68rVpQWyuOY_Az3Jsv05mC2mCsnM&tip=eyJhbGciOiJIUzI1NiJ9.NS4xNzYuNC4w.TdOrpR7ZGEEQVxws5zjS3d6ia2M_Tbhgeodh2iZSRZY"
+      "vast":  "http://localhost:8080/vast/tag"
     },
     "isKSF": true
   },

--- a/app/src/main/java/tv/superawesome/demoapp/MainActivity.kt
+++ b/app/src/main/java/tv/superawesome/demoapp/MainActivity.kt
@@ -222,7 +222,8 @@ class MainActivity : FragmentActivity() {
     }
 
     private fun updateMessage(placementId: Int, event: SAEvent) {
-        val message = "$placementId $event"
+        val originalMessage = subtitleTextView.text
+        val message = "$originalMessage $placementId $event"
         subtitleTextView.text = message
     }
 }

--- a/app/src/main/java/tv/superawesome/demoapp/MainActivity.kt
+++ b/app/src/main/java/tv/superawesome/demoapp/MainActivity.kt
@@ -6,6 +6,7 @@ import android.view.View
 import androidx.fragment.app.FragmentActivity
 import kotlinx.android.synthetic.main.activity_main.*
 import tv.superawesome.demoapp.adapter.*
+import tv.superawesome.demoapp.model.SettingsData
 import tv.superawesome.lib.sabumperpage.SABumperPage
 import tv.superawesome.sdk.publisher.SAEvent
 import tv.superawesome.sdk.publisher.SAInterstitialAd
@@ -103,9 +104,12 @@ class MainActivity : FragmentActivity() {
         }
     }
 
+    private fun getSettings(): SettingsData? {
+        return (application as? MyApplication)?.settings
+    }
+
     private fun updateSettings() {
-        val app = application as? MyApplication ?: return
-        val settings = app.settings
+        val settings = getSettings() ?: return
         val config = settings.environment
 
         bannerView.setConfiguration(config)
@@ -119,7 +123,7 @@ class MainActivity : FragmentActivity() {
         SAVideoAd.setConfiguration(config)
         SAVideoAd.setBumperPage(settings.bumperEnabled)
         SAVideoAd.setParentalGate(settings.parentalEnabled)
-        when (app.settings.closeButtonState) {
+        when (settings.closeButtonState) {
             CloseButtonState.VisibleImmediately -> SAVideoAd.enableCloseButtonNoDelay()
             CloseButtonState.VisibleWithDelay -> SAVideoAd.enableCloseButton()
             CloseButtonState.Hidden -> SAVideoAd.disableCloseButton()
@@ -165,21 +169,15 @@ class MainActivity : FragmentActivity() {
                         }
                     }
                     Type.VIDEO -> {
-                        if (SAVideoAd.hasAdAvailable(item.placementId)) {
-                            Log.i(TAG, "PLAYING VIDEO")
-                            SAVideoAd.play(item.placementId, this@MainActivity)
+                        if (item.isFull()) {
+                            SAVideoAd.load(
+                                item.placementId,
+                                item.lineItemId ?: 0,
+                                item.creativeId ?: 0,
+                                this@MainActivity
+                            )
                         } else {
-                            Log.i(TAG, "LOADING VIDEO")
-                            if (item.isFull()) {
-                                SAVideoAd.load(
-                                    item.placementId,
-                                    item.lineItemId ?: 0,
-                                    item.creativeId ?: 0,
-                                    this@MainActivity
-                                )
-                            } else {
-                                SAVideoAd.load(item.placementId, this@MainActivity)
-                            }
+                            SAVideoAd.load(item.placementId, this@MainActivity)
                         }
                     }
                 }
@@ -193,7 +191,7 @@ class MainActivity : FragmentActivity() {
             updateMessage(placementId, event)
             Log.i(TAG, "SAVideoAd event ${event.name} thread:${Thread.currentThread()}")
 
-            if (event == SAEvent.adLoaded) {
+            if (event == SAEvent.adLoaded && isPlayEnabled()) {
                 SAVideoAd.play(placementId, this@MainActivity)
             }
         }
@@ -204,7 +202,7 @@ class MainActivity : FragmentActivity() {
             updateMessage(placementId, event)
             Log.i(TAG, "SAInterstitialAd event ${event.name} thread:${Thread.currentThread()}")
 
-            if (event == SAEvent.adLoaded) {
+            if (event == SAEvent.adLoaded && isPlayEnabled()) {
                 SAInterstitialAd.play(placementId, this@MainActivity)
             }
         }
@@ -215,10 +213,14 @@ class MainActivity : FragmentActivity() {
         bannerView.setListener { placementId, event ->
             updateMessage(placementId, event)
 
-            if (event == SAEvent.adLoaded) {
+            if (event == SAEvent.adLoaded && isPlayEnabled()) {
                 bannerView.play(this@MainActivity)
             }
         }
+    }
+
+    private fun isPlayEnabled(): Boolean {
+        return getSettings()?.playEnabled == true
     }
 
     private fun updateMessage(placementId: Int, event: SAEvent) {

--- a/app/src/main/java/tv/superawesome/demoapp/SettingsDialogFragment.kt
+++ b/app/src/main/java/tv/superawesome/demoapp/SettingsDialogFragment.kt
@@ -70,6 +70,14 @@ class SettingsDialogFragment : DialogFragment() {
         parentalDisableButton.setOnClickListener {
             app?.updateSettings { it.copy(parentalEnabled = false) }
         }
+
+        playbackEnableButton.setOnClickListener {
+            app?.updateSettings { it.copy(playEnabled = true) }
+        }
+
+        playbackDisableButton.setOnClickListener {
+            app?.updateSettings { it.copy(playEnabled = false) }
+        }
     }
 
     override fun onDismiss(dialog: DialogInterface) {

--- a/app/src/main/java/tv/superawesome/demoapp/model/SettingsData.kt
+++ b/app/src/main/java/tv/superawesome/demoapp/model/SettingsData.kt
@@ -8,5 +8,6 @@ data class SettingsData(
     val environment: SAConfiguration = SAConfiguration.PRODUCTION,
     val closeButtonState: CloseButtonState = CloseButtonState.VisibleWithDelay,
     val bumperEnabled: Boolean = Constants.defaultBumperPage,
-    val parentalEnabled: Boolean = Constants.defaultParentalGate
+    val parentalEnabled: Boolean = Constants.defaultParentalGate,
+    val playEnabled: Boolean = true
 )

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -102,6 +102,23 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/settings_disable" />
+            <TextView
+                android:text="@string/settings_playback"
+                android:textSize="12sp" />
+
+            <Button
+                android:id="@+id/playbackEnableButton"
+                style="@style/SettingsButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_enable" />
+
+            <Button
+                android:id="@+id/playbackDisableButton"
+                style="@style/SettingsButtonStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_disable" />
         </GridLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="settings_enable">Enable</string>
     <string name="settings_disable">Disable</string>
     <string name="settings_parental">Parental Gate</string>
+    <string name="settings_playback">Playback</string>
 </resources>

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/managed/SAManagedAdActivity.kt
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/managed/SAManagedAdActivity.kt
@@ -45,7 +45,6 @@ class SAManagedAdActivity : Activity(), AdViewJavaScriptBridge.Listener {
         closeButton.scaleType = ImageView.ScaleType.FIT_XY
         closeButton.layoutParams = buttonLayout
         closeButton.setOnClickListener {
-            listener?.onEvent(this.placementId, SAEvent.adClosed)
             close()
         }
         closeButton.contentDescription = "Close"
@@ -99,12 +98,12 @@ class SAManagedAdActivity : Activity(), AdViewJavaScriptBridge.Listener {
     }
 
     override fun adClosed() {
-        listener?.onEvent(this.placementId, SAEvent.adClosed)
         close()
     }
 
     private fun close() {
         if (!isFinishing) {
+            listener?.onEvent(this.placementId, SAEvent.adClosed)
             finish()
         }
     }

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/managed/SAManagedAdActivity.kt
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/managed/SAManagedAdActivity.kt
@@ -44,7 +44,10 @@ class SAManagedAdActivity : Activity(), AdViewJavaScriptBridge.Listener {
         closeButton.setPadding(0, 0, 0, 0)
         closeButton.scaleType = ImageView.ScaleType.FIT_XY
         closeButton.layoutParams = buttonLayout
-        closeButton.setOnClickListener { close() }
+        closeButton.setOnClickListener {
+            listener?.onEvent(this.placementId, SAEvent.adClosed)
+            close()
+        }
         closeButton.contentDescription = "Close"
 
         return@lazy closeButton


### PR DESCRIPTION
This PR adds UI tests for the following callbacks (with a few questions - **X** means added). 
I swapped out `checkSubtitle` with `checkSubtitleContains` so we can use it to check the history of callbacks (the callback name gets appended to the label's text)

Note: I added an `adClosed` event on the close button in `SAManagedAdActivity` as it wasn't being sent on the action. Is that correct?

**Banner:**

adLoaded X
adEmpty X
adFailedToLoad X
adAlreadyLoaded: Can this be called for banners?
adShown X
adFailedToShow: It looks like this is called in the case of `Web_Error` but I'm not sure how to replicate this?
adClicked X
adEnded N/A
adClosed X

**Interstitial:**

adLoaded X
adEmpty X
adFailedToLoad X
adAlreadyLoaded - X
adShown X
adFailedToShow - Not sure if this is called?
adClicked X
adEnded X
adClosed X

**Video**

adLoaded X
adEmpty X
adFailedToLoad X
adAlreadyLoaded - X
adShown X (Not called for VPAID?)
adFailedToShow - Not sure if this is called?
adClicked X
adEnded X
adClosed X