### PR TITLE
fix(): This PR prevents the app from going to sleep when playing video ads

### DIFF
--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoActivity.java
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/SAVideoActivity.java
@@ -16,6 +16,7 @@ import android.os.Parcelable;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
@@ -66,6 +67,7 @@ public class SAVideoActivity extends Activity implements IVideoPlayer.Listener, 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
         // get values from the intent
         Intent myIntent = getIntent();

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/managed/SAManagedAdActivity.kt
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/managed/SAManagedAdActivity.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.view.View
+import android.view.WindowManager
 import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.RelativeLayout
@@ -54,6 +55,7 @@ class SAManagedAdActivity : Activity(), AdViewJavaScriptBridge.Listener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         setContentView(adView)
         adView.load(placementId, html, this)
         adView.addView(closeButton)

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/video/VideoActivity.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/video/VideoActivity.kt
@@ -9,6 +9,7 @@ import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import android.view.WindowManager
 import android.widget.RelativeLayout
 import org.koin.core.parameter.parametersOf
 import org.koin.java.KoinJavaComponent.get
@@ -41,6 +42,7 @@ class VideoActivity : FullScreenActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         logger.info("onCreate")
         super.onCreate(savedInstanceState)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     }
 
     override fun onPause() {


### PR DESCRIPTION
This PR prevents apps using the SDK from entering sleep mode when video ads are playing. Device sleep is only prevented whilst the video activities are open, exiting the video screen means sleep mode can occur as normal.