### PR TITLE
AAG-2795: Added missing theme to Bumper

### DIFF
--- a/superawesome-common/src/main/AndroidManifest.xml
+++ b/superawesome-common/src/main/AndroidManifest.xml
@@ -3,23 +3,37 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-    <application>
+    <application
+        android:allowBackup="true"
+        android:supportsRtl="true">
+
         <activity
             android:name=".ui.interstitial.InterstitialActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen" />
+
         <activity
             android:name=".ui.common.BumperPageActivity"
-            android:exported="false" />
+            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:theme="@android:style/Theme.Holo.Dialog.NoActionBar" />
+
         <activity
             android:name=".ui.fullscreen.FullScreenActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen" />
+
         <activity
             android:name=".ui.video.VideoActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
-            android:exported="false" />
+            android:exported="false"
+            android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen" />
+
         <activity
             android:name=".ui.managed.ManagedAdActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
-            android:exported="false" />
+            android:exported="false"
+            android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen" />
     </application>
 </manifest>

--- a/superawesomecomposeexample/src/main/java/com/superawesome/composeexample/ComposeApp.kt
+++ b/superawesomecomposeexample/src/main/java/com/superawesome/composeexample/ComposeApp.kt
@@ -16,5 +16,6 @@ class ComposeApp: Application() {
             configuration = Configuration(environment = Environment.Production, logging = true),
         )
         BumperPageActivity.overrideName(resources.getString(R.string.app_name))
+        BumperPageActivity.overrideLogo(resources.getDrawable(R.mipmap.ic_launcher))
     }
 }


### PR DESCRIPTION
## JIRA
[AAG-2795]

## DESCRIPTION
This PR adds the missing theme to the SDK manifest that enables the bumper to be displayed correctly.
I have also added other missing themes to the video, interstitial and managed ad activities.

## SCREENSHOTS
![Screenshot_20230201_172306](https://user-images.githubusercontent.com/618350/216117122-17aed26f-bc64-4c38-838e-882ed2ab608a.png)

https://user-images.githubusercontent.com/618350/216117128-0466fbf6-6778-4b30-b6dc-40414afc9c0e.mov


[AAG-2795]: https://superawesomeltd.atlassian.net/browse/AAG-2795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ