### PR TITLE
AAG-2796: Added a check to show the parent gate if needed

### DIFF
--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/common/AdController.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/common/AdController.kt
@@ -142,13 +142,9 @@ class AdController(
 
         if (isClickTooFast()) return
 
-        if (config.isParentalGateEnabled) {
-            showParentalGateIfNeeded(context, completion = {
-                showBannerIfNeeded(url, context)
-            })
-        } else {
+        showParentalGateIfNeeded(context, completion = {
             showBannerIfNeeded(url, context)
-        }
+        })
     }
 
     private fun showBannerIfNeeded(url: String, context: Context) {

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/common/AdController.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/common/AdController.kt
@@ -142,6 +142,16 @@ class AdController(
 
         if (isClickTooFast()) return
 
+        if (config.isParentalGateEnabled) {
+            showParentalGateIfNeeded(context, completion = {
+                showBannerIfNeeded(url, context)
+            })
+        } else {
+            showBannerIfNeeded(url, context)
+        }
+    }
+
+    private fun showBannerIfNeeded(url: String, context: Context) {
         if (config.isBumperPageEnabled || currentAdResponse?.ad?.creative?.bumper == true) {
             playBumperPage(url, context)
         } else {

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/common/ParentalGate.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/common/ParentalGate.kt
@@ -68,7 +68,7 @@ class ParentalGate(
                 // go on error way
                 val errorDialog = AlertDialog.Builder(context)
                 errorDialog.setTitle(R.string.parental_gate_error_title)
-                errorDialog.setMessage(R.string.parental_gate_message)
+                errorDialog.setMessage(R.string.parental_gate_error_message)
 
                 // set button action
                 errorDialog.setPositiveButton(context.getString(android.R.string.ok)) { innerDialog, _ ->

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/fullscreen/FullScreenActivity.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/fullscreen/FullScreenActivity.kt
@@ -31,7 +31,7 @@ open class FullScreenActivity : Activity() {
     }
 
     internal val config: Config by lazy {
-        intent?.getParcelableExtra(Constants.Keys.config) ?: Config()
+        intent.getParcelableExtra(Constants.Keys.config) ?: Config()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/managed/ManagedAdActivity.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/managed/ManagedAdActivity.kt
@@ -29,6 +29,7 @@ public class ManagedAdActivity : FullScreenActivity(), AdViewJavaScriptBridge.Li
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.MATCH_PARENT
         )
+        adView.setConfig(config)
         adView.setColor(false)
         adView.setTestMode(config.testEnabled)
         adView.setBumperPage(config.isBumperPageEnabled)

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/managed/ManagedAdView.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/managed/ManagedAdView.kt
@@ -25,6 +25,7 @@ import tv.superawesome.sdk.publisher.common.models.VoidBlock
 import tv.superawesome.sdk.publisher.common.network.Environment
 import tv.superawesome.sdk.publisher.common.ui.banner.CustomWebView
 import tv.superawesome.sdk.publisher.common.ui.common.AdControllerType
+import tv.superawesome.sdk.publisher.common.ui.common.Config
 import tv.superawesome.sdk.publisher.common.ui.common.ViewableDetectorType
 import tv.superawesome.sdk.publisher.common.ui.common.videoMaxTickCount
 
@@ -83,6 +84,10 @@ public class ManagedAdView @JvmOverloads constructor(
 
     public fun setListener(delegate: SAInterface) {
         controller.delegate = delegate
+    }
+
+    public fun setConfig(config: Config) {
+        controller.config = config
     }
 
     /**

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/video/VideoActivity.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/video/VideoActivity.kt
@@ -45,6 +45,7 @@ class VideoActivity : FullScreenActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         logger.info("onCreate")
         super.onCreate(savedInstanceState)
+        controller.config = config
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     }
 

--- a/superawesome-common/src/main/res/values/strings.xml
+++ b/superawesome-common/src/main/res/values/strings.xml
@@ -2,9 +2,10 @@
 <resources>
     <string name="parental_gate_title">Parental Gate</string>
     <string name="parental_gate_message">Please solve the following problem to continue: %1$d + %2$d = ?</string>
-    <string name="parental_gate_error_title">Oops! That was the wrong answer.</string>
+    <string name="parental_gate_error_title">Oops! That was the wrong answer</string>
+    <string name="parental_gate_error_message">Please seek guidance from a responsible adult to help you continue</string>
     <string name="cancel">Cancel</string>
     <string name="proceed">Continue</string>
     <string name="bumper_page_time_left">A new site will open in %1$d seconds. Remember to stay safe online and don’t share your username or password with anyone!</string>
-    <string name="bumper_page_leaving"> Bye! You’re now leaving %1$s.</string>
+    <string name="bumper_page_leaving"> Bye! You’re now leaving %1$s</string>
 </resources>


### PR DESCRIPTION
## JIRA
[AAG-2796]

## DESCRIPTION
This PR fixes the absent Parent Gate on clicking an ad. 

## SCREENSHOTS
![Screenshot_20230201_180035](https://user-images.githubusercontent.com/618350/216127519-3a87a517-8af9-408f-a90e-3675de58d20d.png)
![Screenshot_20230201_180045](https://user-images.githubusercontent.com/618350/216127523-018a47e1-93f4-46a8-b0f8-ad799c9f36ed.png)

https://user-images.githubusercontent.com/618350/216127528-60f37340-4b43-4acd-a2ec-dce9206c8b45.mov


[AAG-2796]: https://superawesomeltd.atlassian.net/browse/AAG-2796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ