### PR TITLE
AAG-2881: Added support for different video close button modes in the unity code

### DIFF
--- a/saunity/src/main/java/tv/superawesome/plugins/publisher/unity/SAUnityVideoAd.java
+++ b/saunity/src/main/java/tv/superawesome/plugins/publisher/unity/SAUnityVideoAd.java
@@ -12,6 +12,7 @@ import tv.superawesome.sdk.publisher.SAEvent;
 import tv.superawesome.sdk.publisher.SAInterface;
 import tv.superawesome.sdk.publisher.SAOrientation;
 import tv.superawesome.sdk.publisher.SAVideoAd;
+import tv.superawesome.sdk.publisher.state.CloseButtonState;
 
 /**
  * Class that holds a number of static methods used to communicate with Unity
@@ -86,7 +87,7 @@ public class SAUnityVideoAd {
                                                       int placementId,
                                                       boolean isParentalGateEnabled,
                                                       boolean isBumperPageEnabled,
-                                                      boolean shouldShowCloseButton,
+                                                      int closeButtonState,
                                                       boolean shouldShowSmallClickButton,
                                                       boolean shouldAutomaticallyCloseAtEnd,
                                                       int orientation,
@@ -95,12 +96,20 @@ public class SAUnityVideoAd {
         SAVideoAd.setParentalGate(isParentalGateEnabled);
         SAVideoAd.setBumperPage(isBumperPageEnabled);
         SAVideoAd.setCloseAtEnd(shouldAutomaticallyCloseAtEnd);
-        SAVideoAd.setCloseButton(shouldShowCloseButton);
         SAVideoAd.setSmallClick(shouldShowSmallClickButton);
         SAVideoAd.setBackButton(isBackButtonEnabled);
         SAVideoAd.setOrientation(SAOrientation.fromValue(orientation));
         SAVideoAd.setCloseButtonWarning(shouldShowCloseWarning);
         SAVideoAd.play(placementId, context);
+
+        switch (CloseButtonState.fromInt(closeButtonState)) {
+            case Hidden:
+                SAVideoAd.disableCloseButton();
+            case VisibleImmediately:
+                SAVideoAd.enableCloseButtonNoDelay();
+            case VisibleWithDelay:
+                SAVideoAd.enableCloseButton();
+        }
     }
 
     /**
@@ -109,7 +118,7 @@ public class SAUnityVideoAd {
     public static void SuperAwesomeUnitySAVideoAdApplySettings(
             boolean isParentalGateEnabled,
             boolean isBumperPageEnabled,
-            boolean shouldShowCloseButton,
+            int closeButtonState,
             boolean shouldShowSmallClickButton,
             boolean shouldAutomaticallyCloseAtEnd,
             int orientation,
@@ -119,11 +128,19 @@ public class SAUnityVideoAd {
         SAVideoAd.setParentalGate(isParentalGateEnabled);
         SAVideoAd.setBumperPage(isBumperPageEnabled);
         SAVideoAd.setCloseAtEnd(shouldAutomaticallyCloseAtEnd);
-        SAVideoAd.setCloseButton(shouldShowCloseButton);
         SAVideoAd.setSmallClick(shouldShowSmallClickButton);
         SAVideoAd.setBackButton(isBackButtonEnabled);
         SAVideoAd.setOrientation(SAOrientation.fromValue(orientation));
         SAVideoAd.setCloseButtonWarning(shouldShowCloseWarning);
         SAVideoAd.setTestMode(testModeEnabled);
+
+        switch (CloseButtonState.fromInt(closeButtonState)) {
+            case Hidden:
+                SAVideoAd.disableCloseButton();
+            case VisibleImmediately:
+                SAVideoAd.enableCloseButtonNoDelay();
+            case VisibleWithDelay:
+                SAVideoAd.enableCloseButton();
+        }
     }
 }

--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/state/CloseButtonState.kt
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/state/CloseButtonState.kt
@@ -1,12 +1,13 @@
 package tv.superawesome.sdk.publisher.state
 
 enum class CloseButtonState(val value: Int) {
-    Hidden(0), VisibleWithDelay(1), VisibleImmediately(2);
+    VisibleWithDelay(0), VisibleImmediately(1), Hidden(2);
 
     fun isVisible(): Boolean =
         this == VisibleWithDelay || this == VisibleImmediately
 
     companion object {
+        @JvmStatic
         fun fromInt(value: Int): CloseButtonState =
             values().firstOrNull { it.value == value } ?: Hidden
     }

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/state/CloseButtonState.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/state/CloseButtonState.kt
@@ -1,7 +1,7 @@
 package tv.superawesome.sdk.publisher.common.state
 
 enum class CloseButtonState(val value: Int) {
-    Hidden(0), VisibleWithDelay(1), VisibleImmediately(2);
+    VisibleWithDelay(0), VisibleImmediately(1), Hidden(2);
 
     fun isVisible(): Boolean =
         this == VisibleWithDelay || this == VisibleImmediately

--- a/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/state/CloseButtonStateTest.kt
+++ b/superawesome-common/src/test/java/tv/superawesome/sdk/publisher/common/state/CloseButtonStateTest.kt
@@ -25,9 +25,9 @@ class CloseButtonStateTest {
     @Test
     fun test_closeButtonState_fromInt() = runTest {
         // Given
-        val hiddenState = CloseButtonState.fromInt(0)
-        val visibleWithDelayState = CloseButtonState.fromInt(1)
-        val visibleImmediatelyState = CloseButtonState.fromInt(2)
+        val hiddenState = CloseButtonState.fromInt(2)
+        val visibleWithDelayState = CloseButtonState.fromInt(0)
+        val visibleImmediatelyState = CloseButtonState.fromInt(1)
 
         // Then
         assertEquals(0, hiddenState.value)


### PR DESCRIPTION
## JIRA
[AAG-2881]

## DESCRIPTION
Added support for different video close button modes in the unity code, replacing the close enabled boolean with an int for the possible states.

I have also changed the order of the `CloseButtonState` enum to mirror iOS.

From: `Hidden(0), VisibleWithDelay(1), VisibleImmediately(2);`

To: `VisibleWithDelay(0), VisibleImmediately(1), Hidden(2);`

## SCREENSHOTS
n/a


[AAG-2881]: https://superawesomeltd.atlassian.net/browse/AAG-2881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ