### PR TITLE
fix(admob): Allow event listener to listen multiple ad loads

### DIFF
--- a/app/src/main/java/tv/superawesome/demoapp/AdMobActivity.kt
+++ b/app/src/main/java/tv/superawesome/demoapp/AdMobActivity.kt
@@ -5,18 +5,14 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.Button
 import com.google.android.gms.ads.*
-import com.google.android.gms.ads.admanager.AdManagerAdRequest
 import com.google.android.gms.ads.admanager.AdManagerInterstitialAd
 import com.google.android.gms.ads.interstitial.InterstitialAd
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
 import com.google.android.gms.ads.rewarded.RewardedAd
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
 import tv.superawesome.plugins.publisher.admob.SAAdMobAdapter
-import tv.superawesome.plugins.publisher.admob.SAAdMobBannerCustomEvent
 import tv.superawesome.plugins.publisher.admob.SAAdMobExtras
-import tv.superawesome.plugins.publisher.admob.SAAdMobInterstitialCustomEvent
 import tv.superawesome.sdk.publisher.SAOrientation
-import tv.superawesome.sdk.publisher.common.models.Orientation
 
 class AdMobActivity : Activity() {
     private val tag = "SADefaults/AdMob"
@@ -52,9 +48,11 @@ class AdMobActivity : Activity() {
             .setParentalGate(false)
             .setTransparent(true)
             .build()
+
         adView.loadAd(
             AdRequest.Builder()
-                .addCustomEventExtrasBundle(SAAdMobBannerCustomEvent::class.java, bundle).build()
+                .addNetworkExtrasBundle(SAAdMobAdapter::class.java, bundle)
+                .build()
         )
     }
 
@@ -62,29 +60,30 @@ class AdMobActivity : Activity() {
         val bundle = SAAdMobExtras.extras()
             .setTestMode(false)
             .setOrientation(SAOrientation.PORTRAIT)
-            .setParentalGate(true)
+            .setParentalGate(false)
             .build()
+
         AdManagerInterstitialAd.load(
             this,
             getString(R.string.admob_interstitial_ad_id),
-            AdManagerAdRequest.Builder().addCustomEventExtrasBundle(
-                SAAdMobInterstitialCustomEvent::class.java, bundle
-            ).build(),
+            AdRequest.Builder()
+                .addNetworkExtrasBundle(SAAdMobAdapter::class.java, bundle)
+                .build(),
             object : InterstitialAdLoadCallback() {
-                override fun onAdLoaded(p0: InterstitialAd) {
-                    super.onAdLoaded(p0)
-                    interstitialAd = p0
+                override fun onAdLoaded(ad: InterstitialAd) {
+                    super.onAdLoaded(ad)
+                    interstitialAd = ad
                     interstitialAd?.show(this@AdMobActivity)
                 }
 
-                override fun onAdFailedToLoad(p0: LoadAdError) {
-                    super.onAdFailedToLoad(p0)
+                override fun onAdFailedToLoad(error: LoadAdError) {
+                    super.onAdFailedToLoad(error)
                 }
             })
     }
 
     private fun requestVideoAd() {
-        val videoBundle = SAAdMobExtras.extras()
+        val bundle = SAAdMobExtras.extras()
             .setTestMode(false)
             .setParentalGate(false)
             .setOrientation(SAOrientation.PORTRAIT)
@@ -92,10 +91,11 @@ class AdMobActivity : Activity() {
             .setCloseAtEnd(true)
             .setCloseButton(true)
             .build()
+
         RewardedAd.load(this,
             getString(R.string.admob_video_ad_id),
-            AdManagerAdRequest.Builder()
-                .addNetworkExtrasBundle(SAAdMobAdapter::class.java, videoBundle)
+            AdRequest.Builder()
+                .addNetworkExtrasBundle(SAAdMobAdapter::class.java, bundle)
                 .build(),
             object : RewardedAdLoadCallback() {
                 override fun onAdFailedToLoad(error: LoadAdError) {
@@ -103,9 +103,9 @@ class AdMobActivity : Activity() {
                     Log.e(tag, error.message)
                 }
 
-                override fun onAdLoaded(p0: RewardedAd) {
-                    super.onAdLoaded(p0)
-                    rewardedAd = p0
+                override fun onAdLoaded(ad: RewardedAd) {
+                    super.onAdLoaded(ad)
+                    rewardedAd = ad
                     rewardedAd?.show(this@AdMobActivity) {
                         Log.e(tag, it.amount.toString())
                     }

--- a/saadmob/src/main/java/tv/superawesome/plugins/publisher/admob/EventListener.kt
+++ b/saadmob/src/main/java/tv/superawesome/plugins/publisher/admob/EventListener.kt
@@ -1,0 +1,60 @@
+package tv.superawesome.plugins.publisher.admob
+
+import android.util.Log
+import tv.superawesome.sdk.publisher.SAEvent
+import tv.superawesome.sdk.publisher.SAInterface
+import java.lang.ref.WeakReference
+
+internal class EventListener : SAInterface {
+    private var observers: MutableList<WeakReference<SAInterface>> = mutableListOf()
+
+    fun subscribe(listener: SAInterface) {
+        observers.forEach {
+            val observer = it.get()
+            if (observer == listener) {
+                Log.d(
+                    "SuperAwesome",
+                    "EventListener subscribe -> Already subscribed"
+                )
+                return
+            }
+        }
+        observers.add(WeakReference(listener))
+        Log.d(
+            "SuperAwesome",
+            "EventListener subscribe -> Subscribed Total: ${observers.count()}"
+        )
+    }
+
+    fun unsubscribe(listener: SAInterface) {
+        observers.forEach {
+            val observer = it.get()
+            if (observer == listener) {
+                observers.remove(it)
+                Log.d(
+                    "SuperAwesome",
+                    "EventListener unsubscribe -> Unsubscribed Total: ${observers.count()}"
+                )
+                return
+            } else if (observer == null) {
+                observers.remove(it)
+                Log.d(
+                    "SuperAwesome",
+                    "EventListener unsubscribe -> Weak reference Total: ${observers.count()}"
+                )
+            }
+        }
+    }
+
+    override fun onEvent(placementId: Int, event: SAEvent?) {
+        observers.forEach {
+            val observer = it.get()
+            observer?.onEvent(placementId, event)
+        }
+    }
+
+    companion object {
+        val videoEvents = EventListener()
+        val interstitialEvents = EventListener()
+    }
+}

--- a/saadmob/src/main/java/tv/superawesome/plugins/publisher/admob/SAAdMobInterstitialAd.kt
+++ b/saadmob/src/main/java/tv/superawesome/plugins/publisher/admob/SAAdMobInterstitialAd.kt
@@ -19,6 +19,11 @@ class SAAdMobInterstitialAd(
     private var adCallback: MediationInterstitialAdCallback? = null
     private var loadedPlacementId = 0
 
+    init {
+        SAInterstitialAd.setListener(EventListener.interstitialEvents)
+        EventListener.interstitialEvents.subscribe(this)
+    }
+
     fun load() {
         val context = adConfiguration.context
 
@@ -45,7 +50,6 @@ class SAAdMobInterstitialAd(
             return
         }
 
-        SAInterstitialAd.setListener(this)
         SAInterstitialAd.load(loadedPlacementId, context)
     }
 
@@ -65,7 +69,7 @@ class SAAdMobInterstitialAd(
             SAEvent.adShown -> adCallback?.onAdOpened()
             SAEvent.adFailedToShow -> adFailedToShown()
             SAEvent.adClicked -> adCallback?.reportAdClicked()
-            SAEvent.adClosed -> adCallback?.onAdClosed()
+            SAEvent.adClosed -> adClosed()
             SAEvent.adEnded -> {
                 // This event is not used
             }
@@ -83,5 +87,10 @@ class SAAdMobInterstitialAd(
     private fun adFailedToShown() {
         adCallback?.onAdFailedToShow(SAAdMobError.adFailedToShow(loadedPlacementId))
         adFailedToLoad()
+    }
+
+    private fun adClosed() {
+        adCallback?.onAdClosed()
+        EventListener.interstitialEvents.unsubscribe(this)
     }
 }

--- a/saadmob/src/main/java/tv/superawesome/plugins/publisher/admob/SAAdMobRewardedAd.kt
+++ b/saadmob/src/main/java/tv/superawesome/plugins/publisher/admob/SAAdMobRewardedAd.kt
@@ -21,6 +21,11 @@ class SAAdMobRewardedAd(
     private var adCallback: MediationRewardedAdCallback? = null
     private var loadedPlacementId = 0
 
+    init {
+        SAVideoAd.setListener(EventListener.videoEvents)
+        EventListener.videoEvents.subscribe(this)
+    }
+
     fun load() {
         val context = adConfiguration.context
 
@@ -48,8 +53,6 @@ class SAAdMobRewardedAd(
             )
             return
         }
-
-        SAVideoAd.setListener(this)
         SAVideoAd.load(loadedPlacementId, context)
     }
 
@@ -65,6 +68,7 @@ class SAAdMobRewardedAd(
 
     // SAVideoAd Listener Event
     override fun onEvent(placementId: Int, event: SAEvent) {
+        if (loadedPlacementId != placementId) return
         when (event) {
             SAEvent.adLoaded, SAEvent.adAlreadyLoaded -> adLoaded()
             SAEvent.adEmpty, SAEvent.adFailedToLoad -> adFailedToLoad()
@@ -72,7 +76,7 @@ class SAAdMobRewardedAd(
             SAEvent.adFailedToShow -> adFailedToShow()
             SAEvent.adClicked -> adCallback?.reportAdClicked()
             SAEvent.adEnded -> adCallback?.onUserEarnedReward(RewardItem.DEFAULT_REWARD)
-            SAEvent.adClosed -> adCallback?.onAdClosed()
+            SAEvent.adClosed -> adClosed()
         }
     }
 
@@ -87,5 +91,10 @@ class SAAdMobRewardedAd(
     private fun adFailedToShow() {
         adCallback?.onAdFailedToShow(SAAdMobError.adFailedToShow(loadedPlacementId))
         adFailedToLoad()
+    }
+
+    private fun adClosed() {
+        adCallback?.onAdClosed()
+        EventListener.videoEvents.unsubscribe(this)
     }
 }

--- a/superawesome-base/src/test/java/tv/superawesome/lib/saversion/TestSAVersion.kt
+++ b/superawesome-base/src/test/java/tv/superawesome/lib/saversion/TestSAVersion.kt
@@ -111,7 +111,9 @@ class TestSAVersion {
     fun test_getSDKVersionNumber_defaults() {
         testVersionNumber(SAVersion.getSDKVersionNumber(), true)
         testVersionNumber("1.2.3", true)
+        testVersionNumber("1.2.3-RC", true)
         testVersionNumber("a.b.c", false)
+        testVersionNumber("a.b.c-12", false)
     }
 
     private fun testVersionNumber(versionNumber: String, isNumeric: Boolean) {
@@ -120,10 +122,8 @@ class TestSAVersion {
             .split("-")
             .first()
 
-
         // when
         val isVersionNumeric = firstPart
-            .replace(".", "")
             .all { char -> char.isDigit() }
 
         // then

--- a/superawesome-base/src/test/java/tv/superawesome/lib/saversion/TestSAVersion.kt
+++ b/superawesome-base/src/test/java/tv/superawesome/lib/saversion/TestSAVersion.kt
@@ -109,16 +109,24 @@ class TestSAVersion {
 
     @Test
     fun test_getSDKVersionNumber_defaults() {
+        testVersionNumber(SAVersion.getSDKVersionNumber(), true)
+        testVersionNumber("1.2.3", true)
+        testVersionNumber("a.b.c", false)
+    }
 
-        // given
-        val sdkVersionNumber = SAVersion.getSDKVersionNumber()
+    private fun testVersionNumber(versionNumber: String, isNumeric: Boolean) {
+        val firstPart = versionNumber
+            .replace(".", "")
+            .split("-")
+            .first()
+
 
         // when
-        val isVersionNumeric = sdkVersionNumber
+        val isVersionNumeric = firstPart
             .replace(".", "")
             .all { char -> char.isDigit() }
 
         // then
-        Assert.assertTrue(isVersionNumeric)
+        Assert.assertEquals(isVersionNumeric, isNumeric)
     }
 }


### PR DESCRIPTION
## JIRA
[AAG-2965]

## DESCRIPTION
fix(admob): Allow event listener for admob adapter to listen multiple ad loads at the same time




[AAG-2965]: https://superawesomeltd.atlassian.net/browse/AAG-2965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ