### PR TITLE
Fix/aasdk 369 close button appears too soon

### DIFF
--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/managed/ManagedAdActivity.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/managed/ManagedAdActivity.kt
@@ -129,9 +129,8 @@ public class ManagedAdActivity :
         viewableDetector.start(adView, videoMaxTickCount) {
             val weakThis = weak.get()
             weakThis?.cancelCloseButtonTimeoutRunnable()
-            weakThis?.closeButton?.visibility =
-                if (weakThis?.config?.closeButtonState == CloseButtonState.VisibleWithDelay)
-                    View.VISIBLE else closeButton.visibility
+            if (weakThis?.config?.closeButtonState == CloseButtonState.VisibleWithDelay)
+                weakThis?.closeButton?.visibility = View.VISIBLE
         }
 
         listener?.onEvent(this.placementId, SAEvent.AdShown)

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/managed/ManagedAdActivity.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/managed/ManagedAdActivity.kt
@@ -129,10 +129,10 @@ public class ManagedAdActivity :
         viewableDetector.start(adView, videoMaxTickCount) {
             val weakThis = weak.get()
             weakThis?.cancelCloseButtonTimeoutRunnable()
+            weakThis?.controller?.triggerViewableImpression(placementId)
             if (weakThis?.config?.closeButtonState == CloseButtonState.VisibleWithDelay)
                 weakThis?.closeButton?.visibility = View.VISIBLE
         }
-
         listener?.onEvent(this.placementId, SAEvent.AdShown)
     }
 


### PR DESCRIPTION
## JIRA
[[AASDK-369](https://superawesomeltd.atlassian.net/browse/AASDK-369)]

## DESCRIPTION

This PR moves the code run by the `viewableDetector` to be triggered after the `adShown` event rather than the `webViewOnStart` method. I've left the `controller.triggerImpressionEvent(placementId)` event on `webViewOnStart` as this was called outside of the `viewableDetector` callback. 

**Note:** showing the close button immediately wasn't working so I've added the setup for that.

**Discussion:**

In the base module the `triggerViewableImpressionEvent` is made by the `viewableDetector` that's started on `webViewOnStart`. I've moved it to the new `viewableDetector` callback, do we think it should remain where it was? I think it should be moved to `adShown`, do we need to confirm this?

```
    override fun webViewOnStart(view: SACustomWebView) {
        viewableDetector.cancel()
        events.triggerImpressionEvent()

        viewableDetector.start(view, videoMaxTickCount) {
            events.triggerViewableImpressionEvent()
        }
    }
```

## SCREENSHOTS

[closeButton.webm](https://user-images.githubusercontent.com/30452349/234644451-9aa0578e-e55c-4697-bc91-ef079663d159.webm)


[AASDK-369]: https://superawesomeltd.atlassian.net/browse/AASDK-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ