### PR TITLE
Fix/aasdk 312 video start issue

### DIFF
--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/videoPlayer/VideoPlayerController.kt
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/videoPlayer/VideoPlayerController.kt
@@ -2,7 +2,10 @@ package tv.superawesome.sdk.publisher.videoPlayer
 
 import android.content.Context
 import android.media.MediaPlayer
-import android.media.MediaPlayer.*
+import android.media.MediaPlayer.OnCompletionListener
+import android.media.MediaPlayer.OnErrorListener
+import android.media.MediaPlayer.OnPreparedListener
+import android.media.MediaPlayer.OnSeekCompleteListener
 import android.net.Uri
 import android.os.CountDownTimer
 
@@ -52,6 +55,10 @@ class VideoPlayerController :
     }
 
     override fun start() {
+        if (!prepared) {
+            // If the video is not ready, skip the "start" function call.
+            return
+        }
         if (completed) {
             // if the video is completed then show the last frame only
             seekTo(currentPosition)

--- a/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/video/player/VideoPlayerController.kt
+++ b/superawesome-common/src/main/java/tv/superawesome/sdk/publisher/common/ui/video/player/VideoPlayerController.kt
@@ -2,7 +2,10 @@ package tv.superawesome.sdk.publisher.common.ui.video.player
 
 import android.content.Context
 import android.media.MediaPlayer
-import android.media.MediaPlayer.*
+import android.media.MediaPlayer.OnCompletionListener
+import android.media.MediaPlayer.OnErrorListener
+import android.media.MediaPlayer.OnPreparedListener
+import android.media.MediaPlayer.OnSeekCompleteListener
 import android.net.Uri
 import android.os.CountDownTimer
 
@@ -52,6 +55,10 @@ internal class VideoPlayerController :
     }
 
     override fun start() {
+        if (!prepared) {
+            // If the video is not ready, skip the "start" function call.
+            return
+        }
         if (completed) {
             // if the video is completed then show the last frame only
             seekTo(currentPosition)


### PR DESCRIPTION
## JIRA
[AASDK-312]

## DESCRIPTION
Fixes the video ad start issue where video ad is failed to be displayed because of a occasional race condition that calls `start` function too early even before the video is ready

## SCREENSHOTS
n/a


[AASDK-312]: https://superawesomeltd.atlassian.net/browse/AASDK-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ