### PR TITLE
chore(): Showing the close button on adEnded if set to hidden

### DIFF
--- a/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/managed/SAManagedAdActivity.kt
+++ b/superawesome-base/src/main/java/tv/superawesome/sdk/publisher/managed/SAManagedAdActivity.kt
@@ -212,6 +212,8 @@ class SAManagedAdActivity : Activity(),
         listener?.onEvent(this.placementId, SAEvent.adEnded)
         if (config?.autoCloseAtEnd == true) {
             close()
+        } else {
+            showCloseButton()
         }
     }
 
@@ -223,6 +225,10 @@ class SAManagedAdActivity : Activity(),
 
     override fun adPaused() {
         listener?.onEvent(this.placementId, SAEvent.adPaused)
+    }
+
+    private fun showCloseButton() = runOnUiThread {
+        closeButton.visibility = View.VISIBLE
     }
 
     private fun onCloseAction() {
@@ -255,7 +261,7 @@ class SAManagedAdActivity : Activity(),
     }
 
     private fun hasBeenVisibleForRequiredTimeoutTime() {
-        closeButton.visibility = View.VISIBLE
+        showCloseButton()
     }
 
     /**


### PR DESCRIPTION
## JIRA
[AASDK-480]

## DESCRIPTION

This PR adds the fix for showing the close button on `adEnded` for IV. Tested manually and with the previously added UI test.


## SCREENSHOTS
n/a


[AASDK-480]: https://superawesomeltd.atlassian.net/browse/AASDK-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ